### PR TITLE
Basic support of high DPI

### DIFF
--- a/native-windows-gui/Cargo.toml
+++ b/native-windows-gui/Cargo.toml
@@ -15,6 +15,7 @@ winapi = { version = "0.3", features = [
 
 bitflags = { version = "1.1.0" }
 stretch = "0.3.2"
+muldiv = { version = "0.2", optional = true }
 
 [dev-dependencies]
 native-windows-derive = { path = "../native-windows-derive/" }
@@ -54,6 +55,7 @@ rich-textbox = []
 image-list = []
 no-styling = []
 embed-resource = []
+high-dpi = ["muldiv"]
 all = ["file-dialog", "color-dialog", "font-dialog", "datetime-picker", "progress-bar", "timer", "notice", "list-view", "cursor", "image-decoder",
        "tabs", "tree-view", "fancy-window", "listbox", "combobox", "tray-notification", "message-window", "number-select", "clipboard", "menu", 
        "trackbar", "extern-canvas", "frame", "tooltip", "status-bar", "winnls", "textbox", "rich-textbox", "image-list", "embed-resource"]

--- a/native-windows-gui/examples/opengl_canvas/src/main.rs
+++ b/native-windows-gui/examples/opengl_canvas/src/main.rs
@@ -136,7 +136,7 @@ impl OpenGlCanvas {
 
     pub fn resize(&self) {
         self.ctx.borrow().as_ref().map(|ctx| unsafe {
-            let (w, h) = self.canvas.size();
+            let (w, h) = self.canvas.physical_size();
             gl::Viewport(0, 0, w as _, h as _);
             ctx.resize(PhysicalSize::new(w as f64, h as f64));
         });
@@ -360,6 +360,9 @@ mod extern_canvas_ui {
 }
 
 pub fn main() {
+    unsafe {
+        nwg::set_dpi_awareness();
+    };
     nwg::init().expect("Failed to init Native Windows GUI");
 
     let app = ExternCanvas::build_ui(Default::default()).expect("Failed to build UI");

--- a/native-windows-gui/src/controls/extern_canvas.rs
+++ b/native-windows-gui/src/controls/extern_canvas.rs
@@ -165,6 +165,13 @@ impl ExternCanvas {
         unsafe { wh::get_window_size(handle) }
     }
 
+    /// Return the physical size of canvas in pixels considering the dpi scale
+    pub fn physical_size(&self) -> (u32, u32) {
+        if self.handle.blank() { panic!(NOT_BOUND); }
+        let handle = self.handle.hwnd().expect(BAD_HANDLE);
+        unsafe { wh::get_window_physical_size(handle) }
+    }
+
     /// Set the size of the button in the parent window
     pub fn set_size(&self, x: u32, y: u32) {
         if self.handle.blank() { panic!(NOT_BOUND); }

--- a/native-windows-gui/src/controls/tabs.rs
+++ b/native-windows-gui/src/controls/tabs.rs
@@ -277,7 +277,12 @@ impl TabsContainer {
         let handler1 = bind_raw_event_handler(&self.handle, handle as usize, move |hwnd, msg, _w, l| { unsafe {
             match msg {
                 WM_SIZE => {
-                    let mut data = (hwnd, LOWORD(l as u32) as u32, HIWORD(l as u32) as u32);
+                    let size = l as u32;
+                    let width = LOWORD(size) as i32;
+                    let height = HIWORD(size) as i32;
+                    let (w, h) = crate::win32::high_dpi::physical_to_logical(width, height);
+
+                    let mut data = (hwnd, w as u32, h as u32);
                     
                     if data.1 > 11 { data.1 -= 11; }
                     if data.2 > 30 { data.2 -= 30; }

--- a/native-windows-gui/src/layouts/flexbox_layout.rs
+++ b/native-windows-gui/src/layouts/flexbox_layout.rs
@@ -470,9 +470,10 @@ impl FlexboxLayoutBuilder {
         let cb = move |_h, msg, _w, l| {
             if msg == WM_SIZE {
                 let size = l as u32;
-                let width = LOWORD(size) as u32;
-                let height = HIWORD(size) as u32;
-                FlexboxLayout::update_layout(&event_layout, width, height).expect("Failed to compute layout!");
+                let width = LOWORD(size) as i32;
+                let height = HIWORD(size) as i32;
+                let (w, h) = unsafe { crate::win32::high_dpi::physical_to_logical(width, height) };
+                FlexboxLayout::update_layout(&event_layout, w as u32, h as u32).expect("Failed to compute layout!");
             }
             None
         };

--- a/native-windows-gui/src/layouts/grid_layout.rs
+++ b/native-windows-gui/src/layouts/grid_layout.rs
@@ -494,9 +494,10 @@ impl GridLayoutBuilder {
         let cb = move |_h, msg, _w, l| {
             if msg == WM_SIZE {
                 let size = l as u32;
-                let width = LOWORD(size) as u32;
-                let height = HIWORD(size) as u32;
-                GridLayout::update_layout(&event_layout, width, height);
+                let width = LOWORD(size) as i32;
+                let height = HIWORD(size) as i32;
+                let (w, h) = unsafe { crate::win32::high_dpi::physical_to_logical(width, height) };
+                GridLayout::update_layout(&event_layout, w as u32, h as u32);
             }
             None
         };

--- a/native-windows-gui/src/lib.rs
+++ b/native-windows-gui/src/lib.rs
@@ -26,6 +26,9 @@ pub use win32::{
  },
  message_box::{MessageButtons, MessageIcons, MessageChoice, MessageParams, message, fatal_message, error_message, simple_message}};
 
+#[allow(deprecated)]
+pub use win32::high_dpi::{set_dpi_awareness, scale_factor, dpi};
+
 #[cfg(feature="cursor")]
 pub use win32::cursor::GlobalCursor;
 

--- a/native-windows-gui/src/tests/mod.rs
+++ b/native-windows-gui/src/tests/mod.rs
@@ -161,6 +161,13 @@ fn close() {
 
 #[test]
 fn everything() {
+    #[cfg(feature = "high-dpi")]
+    {
+        unsafe {
+            crate::win32::high_dpi::set_dpi_awareness();
+        }
+    }
+
     init().expect("Failed to init Native Windows GUI");
     
     let app = TestControlPanel::build_ui(Default::default()).expect("Failed to build UI");

--- a/native-windows-gui/src/win32/high_dpi.rs
+++ b/native-windows-gui/src/win32/high_dpi.rs
@@ -1,0 +1,62 @@
+#[cfg(not(feature = "high-dpi"))]
+#[deprecated(note = "Specifying the default process DPI awareness via API is not recommended. Use the '<dpiAware>true</dpiAware>' setting in the application manifest. https://docs.microsoft.com/ru-ru/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process")]
+pub unsafe fn set_dpi_awareness() {
+}
+
+#[cfg(feature = "high-dpi")]
+#[deprecated(note = "Specifying the default process DPI awareness via API is not recommended. Use the '<dpiAware>true</dpiAware>' setting in the application manifest. https://docs.microsoft.com/ru-ru/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process")]
+pub unsafe fn set_dpi_awareness() {
+    use winapi::um::winuser::SetProcessDPIAware;
+    SetProcessDPIAware();
+}
+
+#[cfg(not(feature = "high-dpi"))]
+pub fn scale_factor() -> f64 {
+    return 1.0;
+}
+
+#[cfg(feature = "high-dpi")]
+pub fn scale_factor() -> f64 {
+    use winapi::um::winuser::USER_DEFAULT_SCREEN_DPI;
+    let dpi = unsafe { dpi() };
+    f64::from(dpi) / f64::from(USER_DEFAULT_SCREEN_DPI)
+}
+
+#[cfg(not(feature = "high-dpi"))]
+pub unsafe fn logical_to_physical(x: i32, y: i32) -> (i32, i32) {
+    (x, y)
+}
+
+#[cfg(feature = "high-dpi")]
+pub unsafe fn logical_to_physical(x: i32, y: i32) -> (i32, i32) {
+    use muldiv::MulDiv;
+    use winapi::um::winuser::USER_DEFAULT_SCREEN_DPI;
+    let dpi = dpi();
+    let x = x.mul_div_round(dpi, USER_DEFAULT_SCREEN_DPI).unwrap_or(x);
+    let y = y.mul_div_round(dpi, USER_DEFAULT_SCREEN_DPI).unwrap_or(y);
+    (x, y)
+}
+
+#[cfg(not(feature = "high-dpi"))]
+pub unsafe fn physical_to_logical(x: i32, y: i32) -> (i32, i32) {
+    (x, y)
+}
+
+#[cfg(feature = "high-dpi")]
+pub unsafe fn physical_to_logical(x: i32, y: i32) -> (i32, i32) {
+    use muldiv::MulDiv;
+    use winapi::um::winuser::USER_DEFAULT_SCREEN_DPI;
+    let dpi = dpi();
+    let x = x.mul_div_round(USER_DEFAULT_SCREEN_DPI, dpi).unwrap_or(x);
+    let y = y.mul_div_round(USER_DEFAULT_SCREEN_DPI, dpi).unwrap_or(y);
+    (x, y)
+}
+
+pub unsafe fn dpi() -> i32 {
+    use winapi::um::winuser::GetDC;
+    use winapi::um::wingdi::GetDeviceCaps;
+    use winapi::um::wingdi::LOGPIXELSX;
+    let screen = GetDC(std::ptr::null_mut());
+    let dpi = GetDeviceCaps(screen, LOGPIXELSX);
+    dpi
+}

--- a/native-windows-gui/src/win32/mod.rs
+++ b/native-windows-gui/src/win32/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod window_helper;
 pub(crate) mod resources_helper;
 pub(crate) mod window;
 pub(crate) mod message_box;
+pub(crate) mod high_dpi;
 
 #[cfg(feature = "menu")]
 pub(crate) mod menu;

--- a/native-windows-gui/src/win32/resources_helper.rs
+++ b/native-windows-gui/src/win32/resources_helper.rs
@@ -45,6 +45,8 @@ pub unsafe fn build_font(
         family_name_ptr = ptr::null();
     }
 
+    let (size, _) = super::high_dpi::logical_to_physical(size as i32, 0);
+
     let handle = CreateFontW(
         size as c_int,            // nHeight
         0, 0, 0,                  // nWidth, nEscapement, nOrientation


### PR DESCRIPTION
Hello, @gabdube!

Thanks for your super cool library. I think it needs to be improved a little bit.

I implemented basic support of high DPI support on the `System DPI Awareness` mode.

https://docs.microsoft.com/ru-ru/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows


To apply, use the feature `high-dpi` and enable high DPI support in the application using the application manifest or by calling the `set_dpi_awareness()` function (not recommended, only for testing purposes).



**Windows 7, 120 dpi (125%)**

without feature `high-dpi`

![120-no](https://user-images.githubusercontent.com/9559317/78450742-3e456d80-769a-11ea-8434-62163aadde5d.png)

with feature `high-dpi`

![120-high](https://user-images.githubusercontent.com/9559317/78450746-42718b00-769a-11ea-9c1b-9bdd2abbfc7a.png)


**Windows 10, 120 dpi (125%)**

without feature `high-dpi`

![120-no](https://user-images.githubusercontent.com/9559317/78450767-6503a400-769a-11ea-8032-2d25ba31d0f5.png)

with feature `high-dpi`

![120-hi](https://user-images.githubusercontent.com/9559317/78450770-6b921b80-769a-11ea-9f6e-d371c6467eb9.png)


Unfortunately, System DPI-aware applications only render crisply at a single display scale factor, becoming blurry whenever the DPI changes. But support of Per-Monitor (V2) DPI Awareness is complicated, because, for example, you also need to change font sizes on the fly.

I implemented:

- window size and position correction. Thus, in the program, we set the position and size of components for the "normal" 96 DPI. Scaling occurs automatically.

- font size correction.

- function, which returns the "real" (physical) size of extern canvas (so that the image generated by OpenGL takes up all the allocated space).


I didn't implement correction of images and icons size. I think, developers should create a set of images and icons for each DPI and use the required set.

