### PR TITLE
Removing icons from the notification area

### DIFF
--- a/native-windows-gui/examples/system_tray.rs
+++ b/native-windows-gui/examples/system_tray.rs
@@ -136,6 +136,7 @@ mod system_tray_ui {
             for handler in handlers.drain(0..) {
                 nwg::unbind_event_handler(&handler);
             }
+            self.tray.delete();
         }
     }
 

--- a/native-windows-gui/examples/system_tray_d.rs
+++ b/native-windows-gui/examples/system_tray_d.rs
@@ -63,7 +63,9 @@ impl SystemTray {
 fn main() {
     nwg::init().expect("Failed to init Native Windows GUI");
 
-    let _ui = SystemTray::build_ui(Default::default()).expect("Failed to build UI");
+    let ui = SystemTray::build_ui(Default::default()).expect("Failed to build UI");
     
     nwg::dispatch_thread_events();
+
+    ui.tray.delete();
 }

--- a/native-windows-gui/src/tests/control_test.rs
+++ b/native-windows-gui/src/tests/control_test.rs
@@ -151,6 +151,15 @@ pub struct ControlsTest {
     run_tray_test: Button,
 }
 
+impl ControlsTest {
+
+    pub fn delete_tray_icons(&self) {
+        self.tray_icon.delete();
+        self.tray_icon_2.delete();
+    }
+
+}
+
 mod partial_controls_test_ui {
     use super::*;
     use crate::{PartialUi, NwgError, ControlHandle};

--- a/native-windows-gui/src/tests/mod.rs
+++ b/native-windows-gui/src/tests/mod.rs
@@ -168,4 +168,6 @@ fn everything() {
     app.window.set_focus();
 
     dispatch_thread_events();
+
+    app.controls_tests.delete_tray_icons();
 }


### PR DESCRIPTION
Windows does not automatically remove icons from the notification area when the app is closed. They remain in the system tray until you hover mouse over them.

![system tray](https://user-images.githubusercontent.com/9559317/78459499-dd865700-76d2-11ea-80e6-2dd5772c5a9d.png)


So, the created icons should be deleted explicitly.

In the proposed PR, the `TrayNotification::delete()` function is added.
