### PR TITLE
Fix documentation formatting for FileDialog.

### DIFF
--- a/native-windows-gui/src/resources/file_dialog.rs
+++ b/native-windows-gui/src/resources/file_dialog.rs
@@ -20,16 +20,15 @@ pub enum FileDialogAction {
     Save,
 }
 
-
 /**
     A file dialog control
 
     The file dialog builders accepts the following parameters:
-        * title: The title of the dialog
-        * action: The action to execute. Open, OpenDirectory for Save
-        * multiselect: Whether the user can select more than one file. Only supported with the Open action
-        * default_folder: Default folder to show in the dialog.
-        * filters: If defined, filter the files that the user can select (In a Open dialog) or which extension to add to the saved file (in a Save dialog)
+    * title: The title of the dialog
+    * action: The action to execute. Open, OpenDirectory for Save
+    * multiselect: Whether the user can select more than one file. Only supported with the Open action
+    * default_folder: Default folder to show in the dialog.
+    * filters: If defined, filter the files that the user can select (In a Open dialog) or which extension to add to the saved file (in a Save dialog)
 
     ```rust
         use native_windows_gui as nwg;


### PR DESCRIPTION
This fixes the list formatting for [`FileDialog`](https://docs.rs/native-windows-gui/1.0.4/native_windows_gui/struct.FileDialog.html)

