### PR TITLE
#119 TextInput Placeholder Text

### DIFF
--- a/native-windows-gui/src/controls/text_input.rs
+++ b/native-windows-gui/src/controls/text_input.rs
@@ -298,8 +298,10 @@ impl TextInput {
         unsafe { wh::set_window_text(handle, v) }
     }
 
-    /// Get the placeholder text displayed in the TextInput
-    /// when it is empty and does not have focus
+    /// Return the placeholder text displayed in the TextInput
+    /// when it is empty and does not have focus. The string returned will be
+    /// as long as the user specified, however it might be longer or shorter than
+    /// the actual placeholder text.
     pub fn placeholder_text<'a>(&self, text_length: usize) -> String { 
         let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
         wh::get_placeholder_text(handle, text_length)

--- a/native-windows-gui/src/controls/text_input.rs
+++ b/native-windows-gui/src/controls/text_input.rs
@@ -84,6 +84,7 @@ impl TextInput {
     pub fn builder<'a>() -> TextInputBuilder<'a> {
         TextInputBuilder {
             text: "",
+            placeholder_text: None,
             size: (100, 25),
             position: (0, 0),
             flags: None,
@@ -297,6 +298,20 @@ impl TextInput {
         unsafe { wh::set_window_text(handle, v) }
     }
 
+    /// Get the placeholder text displayed in the TextInput
+    /// when it is empty and does not have focus
+    pub fn placeholder_text<'a>(&self, text_length: usize) -> String { 
+        let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
+        wh::get_placeholder_text(handle, text_length)
+    }
+
+    /// Set the placeholder text displayed in the TextInput
+    /// when it is empty and does not have focus
+    pub fn set_placeholder_text<'a>(&self, v: Option<&'a str>) {
+        let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
+        wh::set_placeholder_text(handle, v.unwrap_or(""));
+    }
+
     /// Winapi class name used during control creation
     pub fn class_name(&self) -> &'static str {
         "EDIT"
@@ -431,6 +446,7 @@ impl Drop for TextInput {
 
 pub struct TextInputBuilder<'a> {
     text: &'a str,
+    placeholder_text: Option<&'a str>,
     size: (i32, i32),
     position: (i32, i32),
     flags: Option<TextInputFlags>,
@@ -453,6 +469,11 @@ impl<'a> TextInputBuilder<'a> {
 
     pub fn text(mut self, text: &'a str) -> TextInputBuilder<'a> {
         self.text = text;
+        self
+    }
+
+    pub fn placeholder_text(mut self, placeholder_text: Option<&'a str>) -> TextInputBuilder<'a> {
+        self.placeholder_text = placeholder_text;
         self
     }
 
@@ -558,6 +579,10 @@ impl<'a> TextInputBuilder<'a> {
             out.set_font(self.font);
         } else {
             out.set_font(Font::global_default().as_ref());
+        }
+
+        if self.placeholder_text.is_some() {
+            out.set_placeholder_text(self.placeholder_text);
         }
 
         Ok(())

--- a/native-windows-gui/src/tests/control_test.rs
+++ b/native-windows-gui/src/tests/control_test.rs
@@ -557,6 +557,7 @@ mod partial_controls_test_ui {
 
             TextInput::builder()
                 .parent(&data.dialog_tab)
+                .placeholder_text(Some("The color will go here"))
                 .background_color(Some([255, 255, 255]))
                 .build(&mut data.test_color_output)?;
 
@@ -568,6 +569,7 @@ mod partial_controls_test_ui {
 
             TextInput::builder()
                 .parent(&data.dialog_tab)
+                .placeholder_text(Some("The font will go here"))
                 .background_color(Some([255, 255, 255]))
                 .build(&mut data.test_font_output)?;
 

--- a/native-windows-gui/src/win32/window_helper.rs
+++ b/native-windows-gui/src/win32/window_helper.rs
@@ -315,3 +315,26 @@ pub fn set_window_long(handle: HWND, index: c_int, v: usize) {
 pub fn set_window_long(handle: HWND, index: c_int, v: usize) {
     unsafe { ::winapi::um::winuser::SetWindowLongW(handle, index, v as LONG); }
 }
+
+pub fn get_placeholder_text(handle: HWND, text_length: usize) -> String {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use winapi::shared::ntdef::WCHAR;
+    use winapi::um::commctrl::EM_GETCUEBANNER;
+    use winapi::um::winuser::SendMessageW;
+
+    let mut placeholder_text: Vec<WCHAR> = Vec::with_capacity(text_length);
+    unsafe {
+        placeholder_text.set_len(text_length);
+        SendMessageW(handle, EM_GETCUEBANNER, placeholder_text.as_mut_ptr() as WPARAM, placeholder_text.len() as LPARAM);
+        OsString::from_wide(&placeholder_text).into_string().unwrap_or("".to_string())
+    }
+}
+
+pub fn set_placeholder_text<'a>(handle: HWND, placeholder_text: &'a str) {
+    use winapi::um::commctrl::EM_SETCUEBANNER;
+    use winapi::um::winuser::SendMessageW;
+
+    let text = to_utf16(placeholder_text);
+    unsafe { SendMessageW(handle, EM_SETCUEBANNER, 0, text.as_ptr() as LPARAM) };
+}


### PR DESCRIPTION
Work in progress.. but the goal of this PR is to implement support for setting/getting the placeholder text of a `TextInput`.

- Not sure if the actual call to `SendMessageW` should be in the `window_helper.rs` as it does not really apply to every window.
- Not quite sure if it should be called "set_placeholder_text" or if it should be called "set_cue_banner_text" as the API suggests. Let me know what you think and I'll adjust it accordingly.
- Not sure if the test is good, I added a "placeholder_text" to the color/font `TextInput`'s in the controls example.
- Should probably add API test for set/get if it is available for other API functions.
- It seems that there is a setting if the text should be shown while the control has focus as well. This can be done utilizing the wParam according to: https://docs.microsoft.com/en-us/windows/win32/controls/em-setcuebanner, I will add it.