### PR TITLE
Fixed image loading from byte stream

### DIFF
--- a/native-windows-gui/src/resources/image_decoder.rs
+++ b/native-windows-gui/src/resources/image_decoder.rs
@@ -13,10 +13,7 @@ pub struct LifetimeRef<'a, T: 'a> {
 
 impl<'a, T> Deref for LifetimeRef<'a, T> {
     type Target = T;
-    fn deref(&self) -> &T {
-        let r: &'a T = unsafe { mem::transmute_copy(&self.owned_ref) };
-        r
-    }
+    fn deref(&self) -> &T { self.owned_ref }
 }
 
 impl<'a, T> From<T> for LifetimeRef<'a, T> {

--- a/native-windows-gui/src/resources/image_decoder.rs
+++ b/native-windows-gui/src/resources/image_decoder.rs
@@ -3,7 +3,35 @@ use winapi::shared::winerror::S_OK;
 use crate::win32::image_decoder as img;
 use crate::{NwgError, Bitmap};
 use std::{ptr, mem};
+use std::ops::Deref;
 
+static EMPTY_VEC: Vec<u8> = vec![];
+
+pub struct LifetimeRef<'a, T: 'a> {
+    owned_ref: &'a mut T,
+}
+
+impl<'a, T> Deref for LifetimeRef<'a, T> {
+    type Target = &'a T;
+    fn deref(&self) -> &&'a T {
+        let r: &&'a T = unsafe { mem::transmute(&self.owned_ref) };
+        r
+    }
+}
+
+impl<'a, T> From<T> for LifetimeRef<'a, T> {
+    fn from(value: T) -> Self {
+        let boxed = Box::new(value);
+        Self { owned_ref: Box::leak(boxed) }
+    }
+}
+
+impl<'a, T> Drop for LifetimeRef<'a, T> {
+    fn drop(&mut self) {
+        let boxed = unsafe { Box::from_raw(self.owned_ref as *mut T) };
+        drop(boxed);
+    }
+} 
 
 /**
     A image decoder. Can load an extended number of image file format from a filename, from a file handle, or from a stream.
@@ -56,14 +84,14 @@ impl ImageDecoder {
 
         This method returns a ImageSource object
     */
-    pub fn from_filename<'a>(&self, path: &'a str) -> Result<ImageSource, NwgError> {
+    pub fn from_filename<'a, 'b>(&self, path: &'a str) -> Result<LifetimeRef<'b, ImageSource>, NwgError> {
         if self.factory.is_null() {
             panic!("ImageDecoder is not yet bound to a winapi object");
         }
 
         let decoder = unsafe { img::create_decoder_from_file(&*self.factory, path) }?;
 
-        Ok(ImageSource { decoder })
+        Ok(LifetimeRef::from(ImageSource { decoder, stream: EMPTY_VEC.as_slice() }))
     }
 
     /**
@@ -75,14 +103,14 @@ impl ImageDecoder {
 
         This method copies the bytes and returns a ImageSource object
     */
-    pub fn from_stream(&self, stream: &[u8]) -> Result<ImageSource, NwgError> {
+    pub fn from_stream<'a>(&self, stream: &'a mut [u8]) -> Result<LifetimeRef<'a, ImageSource<'a>>, NwgError> {
         if self.factory.is_null() {
             panic!("ImageDecoder is not yet bound to a winapi object");
         }
 
         let decoder = unsafe { img::create_decoder_from_stream(&*self.factory, stream) }?;
 
-        Ok(ImageSource { decoder })
+        Ok(LifetimeRef::from(ImageSource { decoder, stream }))
     }
 
     /**
@@ -98,11 +126,13 @@ impl ImageDecoder {
 /**
     Represents a image data source in read only mode.
 */
-pub struct ImageSource {
-    pub decoder: *mut IWICBitmapDecoder
+pub struct ImageSource<'a> {
+    pub decoder: *mut IWICBitmapDecoder,
+    #[allow(dead_code)]
+    stream: &'a [u8],
 }
 
-impl ImageSource {
+impl<'a> ImageSource<'a> {
 
     /**
         Return the number of frame in the image. For most format (ex: PNG), this will be 1.
@@ -117,11 +147,11 @@ impl ImageSource {
     /**
         Return the image data of the requested frame in a ImageData object.
     */
-    pub fn frame(&self, index: u32) -> Result<ImageData, NwgError> {
+    pub fn frame<'b>(&self, index: u32) -> Result<LifetimeRef<'b, ImageData>, NwgError> where 'a : 'b {
         let mut bitmap = ptr::null_mut();
         let hr = unsafe { (&*self.decoder).GetFrame(index, &mut bitmap) };
         match hr {
-            S_OK => Ok(ImageData { frame: bitmap as *mut IWICBitmapSource }),
+            S_OK => Ok(LifetimeRef::from(ImageData { frame: bitmap as *mut IWICBitmapSource })),
             err => Err(NwgError::image_decoder(err, "Could not read image frame"))
         }
     }
@@ -289,7 +319,7 @@ impl Drop for ImageDecoder {
     }
 }
 
-impl Drop for ImageSource {
+impl<'a> Drop for ImageSource<'a> {
     fn drop(&mut self) {
         unsafe { (&*self.decoder).Release(); }
     }

--- a/native-windows-gui/src/resources/image_decoder.rs
+++ b/native-windows-gui/src/resources/image_decoder.rs
@@ -144,7 +144,7 @@ impl<'a> ImageSource<'a> {
     /**
         Return the image data of the requested frame in a ImageData object.
     */
-    pub fn frame<'b>(&self, index: u32) -> Result<LifetimeRef<'b, ImageData>, NwgError> where 'a : 'b {
+    pub fn frame<'b>(&'a self, index: u32) -> Result<LifetimeRef<'b, ImageData>, NwgError> where 'a : 'b {
         let mut bitmap = ptr::null_mut();
         let hr = unsafe { (&*self.decoder).GetFrame(index, &mut bitmap) };
         match hr {

--- a/native-windows-gui/src/resources/image_decoder.rs
+++ b/native-windows-gui/src/resources/image_decoder.rs
@@ -12,9 +12,9 @@ pub struct LifetimeRef<'a, T: 'a> {
 }
 
 impl<'a, T> Deref for LifetimeRef<'a, T> {
-    type Target = &'a T;
-    fn deref(&self) -> &&'a T {
-        let r: &&'a T = unsafe { mem::transmute(&self.owned_ref) };
+    type Target = T;
+    fn deref(&self) -> &T {
+        let r: &'a T = unsafe { mem::transmute_copy(&self.owned_ref) };
         r
     }
 }

--- a/native-windows-gui/src/win32/image_decoder.rs
+++ b/native-windows-gui/src/win32/image_decoder.rs
@@ -50,7 +50,7 @@ pub unsafe fn create_decoder_from_file<'a>(fact: &IWICImagingFactory, path: &'a 
     Ok(decoder)
 }
 
-pub unsafe fn create_decoder_from_stream(fact: &IWICImagingFactory, data: &[u8]) -> Result<*mut IWICBitmapDecoder, NwgError> {
+pub unsafe fn create_decoder_from_stream(fact: &IWICImagingFactory, stream_data: &mut [u8]) -> Result<*mut IWICBitmapDecoder, NwgError> {
     use winapi::um::wincodec::WICDecodeMetadataCacheOnDemand;
 
     let mut stream = ptr::null_mut();
@@ -59,11 +59,7 @@ pub unsafe fn create_decoder_from_stream(fact: &IWICImagingFactory, data: &[u8])
         return Err(NwgError::resource_create("Failed to create a stream for bitmap decoder"));
     }
 
-    // For some reason, `InitializeFromMemory` requires a mutable ptr, so we need to copy the data first.
-    let mut stream_data: Vec<u8> = Vec::with_capacity(data.len());
-    stream_data.set_len(data.len());
-    ptr::copy_nonoverlapping(data.as_ptr(), stream_data.as_mut_ptr(), data.len());
-
+    //Stream data must never be removed while stream is in use. See https://docs.microsoft.com/en-us/windows/win32/api/wincodec/nf-wincodec-iwicstream-initializefrommemory
     let r = (&*stream).InitializeFromMemory(stream_data.as_mut_ptr(), stream_data.len() as _);
     if r != S_OK {
         return Err(NwgError::resource_create("Failed to initialize stream from memory"));

--- a/native-windows-gui/src/win32/resources_helper.rs
+++ b/native-windows-gui/src/win32/resources_helper.rs
@@ -131,7 +131,7 @@ pub unsafe fn build_image_decoder<'a>(
         .frame(0)?;
 
     if let Some((width, height)) = size {
-        image_frame = decoder.resize_image(*image_frame, [width, height])?.into();
+        image_frame = decoder.resize_image(&*image_frame, [width, height])?.into();
     }
     
     let mut bitmap = image_frame.as_bitmap()?;
@@ -158,7 +158,7 @@ pub unsafe fn build_image_decoder_from_memory<'a>(
         .frame(0)?;
 
     if let Some((width, height)) = size {
-        image_frame = decoder.resize_image(*image_frame, [width, height])?.into();
+        image_frame = decoder.resize_image(&*image_frame, [width, height])?.into();
     }
     
     let mut bitmap = image_frame.as_bitmap()?;

--- a/native-windows-gui/src/win32/resources_helper.rs
+++ b/native-windows-gui/src/win32/resources_helper.rs
@@ -131,7 +131,7 @@ pub unsafe fn build_image_decoder<'a>(
         .frame(0)?;
 
     if let Some((width, height)) = size {
-        image_frame = decoder.resize_image(&image_frame, [width, height])?;
+        image_frame = decoder.resize_image(*image_frame, [width, height])?.into();
     }
     
     let mut bitmap = image_frame.as_bitmap()?;
@@ -149,6 +149,8 @@ pub unsafe fn build_image_decoder_from_memory<'a>(
 {
     use crate::ImageDecoder;
 
+    let mut v = Vec::from(src);
+    let src = v.as_mut_slice();
     let decoder = ImageDecoder::new()?;
 
     let mut image_frame = decoder
@@ -156,7 +158,7 @@ pub unsafe fn build_image_decoder_from_memory<'a>(
         .frame(0)?;
 
     if let Some((width, height)) = size {
-        image_frame = decoder.resize_image(&image_frame, [width, height])?;
+        image_frame = decoder.resize_image(*image_frame, [width, height])?.into();
     }
     
     let mut bitmap = image_frame.as_bitmap()?;

--- a/native-windows-gui/src/win32/resources_helper.rs
+++ b/native-windows-gui/src/win32/resources_helper.rs
@@ -130,7 +130,7 @@ pub unsafe fn build_image_decoder<'a>(
     let mut image_frame = image_source.frame(0)?;
 
     if let Some((width, height)) = size {
-        image_frame = decoder.resize_image(&*image_frame, [width, height])?.into();
+        image_frame = decoder.resize_image(&image_frame, [width, height])?.into();
     }
     
     let mut bitmap = image_frame.as_bitmap()?;
@@ -156,7 +156,7 @@ pub unsafe fn build_image_decoder_from_memory<'a>(
     let mut image_frame = image_source.frame(0)?;
 
     if let Some((width, height)) = size {
-        image_frame = decoder.resize_image(&*image_frame, [width, height])?.into();
+        image_frame = decoder.resize_image(&image_frame, [width, height])?.into();
     }
     
     let mut bitmap = image_frame.as_bitmap()?;

--- a/native-windows-gui/src/win32/resources_helper.rs
+++ b/native-windows-gui/src/win32/resources_helper.rs
@@ -126,9 +126,8 @@ pub unsafe fn build_image_decoder<'a>(
 
     let decoder = ImageDecoder::new()?;
 
-    let mut image_frame = decoder
-        .from_filename(source)?
-        .frame(0)?;
+    let image_source = decoder.from_filename(source)?;
+    let mut image_frame = image_source.frame(0)?;
 
     if let Some((width, height)) = size {
         image_frame = decoder.resize_image(&*image_frame, [width, height])?.into();
@@ -153,9 +152,8 @@ pub unsafe fn build_image_decoder_from_memory<'a>(
     let src = v.as_mut_slice();
     let decoder = ImageDecoder::new()?;
 
-    let mut image_frame = decoder
-        .from_stream(src)?
-        .frame(0)?;
+    let image_source = decoder.from_stream(src)?;
+    let mut image_frame = image_source.frame(0)?;
 
     if let Some((width, height)) = size {
         image_frame = decoder.resize_image(&*image_frame, [width, height])?.into();


### PR DESCRIPTION
Minimal changes in API were required.
Added additional reference inside ImageSource.
ImageSource and ImageData are now wrapped in LifetimeRef.
It didn't change much, since it implements deref.
Also they usually don't require mutation and are local.