### PR TITLE
Fixed memory leaks for image decoder and controls

### DIFF
--- a/native-windows-gui/src/controls/image_frame.rs
+++ b/native-windows-gui/src/controls/image_frame.rs
@@ -1,4 +1,5 @@
 use winapi::um::winuser::{WS_VISIBLE, WS_DISABLED};
+use winapi::um::wingdi::DeleteObject;
 use crate::win32::{
     base_helper::check_hwnd,  
     window_helper as wh,
@@ -78,7 +79,10 @@ impl ImageFrame {
         let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
 
         let image_handle = image.map(|i| i.handle as LPARAM).unwrap_or(0);
-        wh::send_message(handle, STM_SETIMAGE, IMAGE_BITMAP as WPARAM, image_handle);
+        let prev_img = wh::send_message(handle, STM_SETIMAGE, IMAGE_BITMAP as WPARAM, image_handle);
+        if prev_img != 0 {
+            unsafe { DeleteObject(prev_img as _); }
+        }
     }
 
     /// Sets the bitmap image of the image frame. Replace the current bitmap or icon.
@@ -90,7 +94,10 @@ impl ImageFrame {
         let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
 
         let image_handle = image.map(|i| i.handle as LPARAM).unwrap_or(0);
-        wh::send_message(handle, STM_SETIMAGE, IMAGE_ICON as WPARAM, image_handle);
+        let prev_img = wh::send_message(handle, STM_SETIMAGE, IMAGE_ICON as WPARAM, image_handle);
+        if prev_img != 0 {
+            unsafe { DeleteObject(prev_img as _); }
+        }
     }
 
     /// Returns the current image in the image frame.

--- a/native-windows-gui/src/win32/image_decoder.rs
+++ b/native-windows-gui/src/win32/image_decoder.rs
@@ -77,6 +77,8 @@ pub unsafe fn create_decoder_from_stream(fact: &IWICImagingFactory, data: &[u8])
         (&mut decoder as *mut *mut IWICBitmapDecoder) as *mut *mut IWICBitmapDecoder
     );
 
+    (*stream).Release();
+
     if r != S_OK {
         return Err(NwgError::resource_create("Failed to create decoder from stream"));
     }


### PR DESCRIPTION
Horrible memory leaks if I update bitmap in `ImageFrame` every second