### PR TITLE
Disable WS_EX_COMPOSITED, enable list view headers

### DIFF
--- a/native-windows-gui/src/controls/list_view.rs
+++ b/native-windows-gui/src/controls/list_view.rs
@@ -507,6 +507,27 @@ impl ListView {
         wh::send_message(handle, LVM_DELETECOLUMN , column_index as _, 0);
     }
 
+    /// Returns true if list view headers are visible
+    pub fn headers_enabled(&self) -> bool {
+        let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
+        let style = wh::get_style(handle);
+        (style & LVS_REPORT == LVS_REPORT) &&
+            (style & LVS_NOCOLUMNHEADER != LVS_NOCOLUMNHEADER)
+    }
+
+    /// Enable or disable list view headers
+    pub fn set_headers_enabled(&self, enable: bool) {
+        let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
+        let style = wh::get_style(handle);
+        if style & LVS_REPORT == LVS_REPORT {
+            if !enable {
+                wh::set_style(handle, style | LVS_NOCOLUMNHEADER);
+            } else {
+                wh::set_style(handle, style & !LVS_NOCOLUMNHEADER);
+            }
+        }
+    }
+
     /// Select or unselect an item at `row_index`. Does nothing if the index is out of bounds.
     pub fn select_item(&self, row_index: usize, selected: bool) {
         use winapi::um::commctrl::{LVM_SETITEMW, LVIF_STATE, LVIS_SELECTED};

--- a/native-windows-gui/src/controls/list_view.rs
+++ b/native-windows-gui/src/controls/list_view.rs
@@ -26,7 +26,7 @@ bitflags! {
         * VISIBLE:  The list view is immediatly visible after creation
         * DISABLED: The list view cannot be interacted with by the user. It also has a grayed out look. The user can drag the items to any location in the list-view window.
         * TAB_STOP: The control can be selected using tab navigation
-        * NO_HEADER: Remove the headers in Detailed view (always ON, see "Listview header problem" section in ListView docs as of why)
+        * NO_HEADER: Remove the headers in Detailed view (ON by default, use `ListView::set_headers_enabled` to enable headers)
         * SINGLE_SELECTION: Only one item can be selected
         * ALWAYS_SHOW_SELECTION: Shows the selected list view item when the control is not in focus
     */
@@ -39,7 +39,8 @@ bitflags! {
 
         const ALWAYS_SHOW_SELECTION = LVS_SHOWSELALWAYS;
 
-        // Remove the headers in Detailed view (always ON, see "Listview header problem" section in ListView docs as of why)
+        // Remove the headers in Detailed view (ON by default due to backward compatibility)
+        // TODO: OFF by default in next major releases
         const NO_HEADER = LVS_NOCOLUMNHEADER;
     }
 }
@@ -247,10 +248,6 @@ Builder parameters:
   * `OnListViewItemChanged`: When an item is selected/unselected in the listview
   * `OnListViewFocus`: When the list view has received focus
   * `OnListViewFocusLost`: When the list view has lost focus
-
-Listview header problem:
-- The win32 header controls leaks megabytes of memory per seconds because of some issues with the rendering. 
-As such, NO_HEADER is always ON.  
 
 */
 #[derive(Default)]

--- a/native-windows-gui/src/controls/window.rs
+++ b/native-windows-gui/src/controls/window.rs
@@ -3,7 +3,7 @@
 */
 
 use winapi::um::winuser::{WS_OVERLAPPEDWINDOW, WS_CLIPCHILDREN, WS_VISIBLE, WS_DISABLED, WS_MAXIMIZE, WS_MINIMIZE, WS_CAPTION,
-WS_MINIMIZEBOX, WS_MAXIMIZEBOX, WS_SYSMENU, WS_THICKFRAME, WS_POPUP, WS_EX_TOPMOST, WS_EX_ACCEPTFILES, WS_EX_COMPOSITED};
+WS_MINIMIZEBOX, WS_MAXIMIZEBOX, WS_SYSMENU, WS_THICKFRAME, WS_POPUP, WS_EX_TOPMOST, WS_EX_ACCEPTFILES};
 
 use crate::win32::window_helper as wh;
 use crate::win32::base_helper::check_hwnd;
@@ -297,7 +297,7 @@ impl<'a> WindowBuilder<'a> {
     pub fn build(self, out: &mut Window) -> Result<(), NwgError> {
         let flags = self.flags.map(|f| f.bits()).unwrap_or(out.flags());
 
-        let mut ex_flags = WS_EX_COMPOSITED;
+        let mut ex_flags = 0;
         if self.topmost { ex_flags |= WS_EX_TOPMOST; }
         if self.accept_files { ex_flags |= WS_EX_ACCEPTFILES; }
 

--- a/native-windows-gui/src/tests/control_test.rs
+++ b/native-windows-gui/src/tests/control_test.rs
@@ -966,13 +966,13 @@ fn init_tree(app: &ControlsTest) {
 fn init_list_view(app: &ControlsTest) {
     let list = &app.test_list_view;
 
-    // Columns are invisible, but they still need to be defined.
     for &column in &["Name", "Price", "Quantity"] {
         list.insert_column(column);
     }
+    list.set_headers_enabled(true);
 
     let data: &[&[&str]] = &[
-        &["Name", "Price (USD $)", "Quantity"],
+        // &["Name", "Price (USD $)", "Quantity"],
         &["Banana", "10.0", "1000"],
         &["Apple", "2.0", "345"],
         &["Kiwi", "5.0", "194"],

--- a/native-windows-gui/src/win32/window.rs
+++ b/native-windows-gui/src/win32/window.rs
@@ -375,7 +375,7 @@ pub(crate) unsafe fn build_hwnd_control<'a>(
     parent: Option<HWND>
 ) -> Result<ControlHandle, NwgError> 
 {
-    use winapi::um::winuser::{WS_EX_COMPOSITED, WS_OVERLAPPEDWINDOW, WS_VISIBLE, WS_CLIPCHILDREN, /*WS_EX_LAYERED*/};
+    use winapi::um::winuser::{WS_OVERLAPPEDWINDOW, WS_VISIBLE, WS_CLIPCHILDREN, /*WS_EX_LAYERED*/};
     use winapi::um::winuser::{CreateWindowExW, AdjustWindowRectEx};
     use winapi::shared::windef::RECT;
     use winapi::um::libloaderapi::GetModuleHandleW;
@@ -385,7 +385,7 @@ pub(crate) unsafe fn build_hwnd_control<'a>(
 
     let class_name = to_utf16(class_name);
     let window_title = to_utf16(window_title.unwrap_or("New Window"));
-    let ex_flags = ex_flags.unwrap_or(WS_EX_COMPOSITED);
+    let ex_flags = ex_flags.unwrap_or(0);
     let flags = flags.unwrap_or(WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN | WS_VISIBLE) | forced_flags;
 
     let pos = pos.unwrap_or((0, 0));


### PR DESCRIPTION
Hi Gabriel

I've implemented headers for `ListView` control. The problem is list view is not compatible with `WS_EX_COMPOSITED` style. I disabled this style because IMHO it's the best problem generator. It also fixes flicker on `Tab` controls. You no longer need to implement custom `WM_PAINT` handler to fix it. Tabs started highlighting on hover.

I hope it won't break compatibility but you're the deciding vote, boss.