### PR TITLE
Sort arrows in list view controls

### DIFF
--- a/native-windows-gui/src/controls/list_view.rs
+++ b/native-windows-gui/src/controls/list_view.rs
@@ -543,10 +543,10 @@ impl ListView {
         let headers = wh::send_message(handle, LVM_GETHEADER, 0, 0);
         if headers == 0 { return None; }
 
-        let mut header: HDITEMW = unsafe { std::mem::zeroed() };
+        let mut header: HDITEMW = unsafe { mem::zeroed() };
         header.mask = HDI_FORMAT;
 
-        let l = unsafe { std::mem::transmute(&mut header) };
+        let l = &mut header as *mut HDITEMW as _;
         wh::send_message(headers as *mut _, HDM_GETITEMW, column_index, l);
 
         match header.fmt & (HDF_SORTUP | HDF_SORTDOWN) {
@@ -562,10 +562,10 @@ impl ListView {
 
         let headers = wh::send_message(handle, LVM_GETHEADER, 0, 0);
         if headers != 0 {
-            let mut header: HDITEMW = unsafe { std::mem::zeroed() };
+            let mut header: HDITEMW = unsafe { mem::zeroed() };
             header.mask = HDI_FORMAT;
 
-            let l = unsafe { std::mem::transmute(&mut header) };
+            let l = &mut header as *mut HDITEMW as _;
             wh::send_message(headers as *mut _, HDM_GETITEMW, column_index, l);
 
             header.fmt &= !(HDF_SORTUP | HDF_SORTDOWN);
@@ -575,7 +575,7 @@ impl ListView {
                 _ => {}
             };
 
-            let l = unsafe { std::mem::transmute(&mut header) };
+            let l = &mut header as *mut HDITEMW as _;
             wh::send_message(headers as *mut _, HDM_SETITEMW, column_index, l);
         }
     }

--- a/native-windows-gui/src/controls/list_view.rs
+++ b/native-windows-gui/src/controls/list_view.rs
@@ -185,8 +185,8 @@ pub struct ListViewColumn {
 /// Represents a column sort indicator in a detailed list view
 #[derive(Copy, Clone, Debug)]
 pub enum ListViewColumnSortArrow {
-    UP,
-    DOWN,
+    Up,
+    Down,
 }
 
 
@@ -550,8 +550,8 @@ impl ListView {
         wh::send_message(headers as *mut _, HDM_GETITEMW, column_index, l);
 
         match header.fmt & (HDF_SORTUP | HDF_SORTDOWN) {
-            HDF_SORTUP => Some(ListViewColumnSortArrow::UP),
-            HDF_SORTDOWN => Some(ListViewColumnSortArrow::DOWN),
+            HDF_SORTUP => Some(ListViewColumnSortArrow::Up),
+            HDF_SORTDOWN => Some(ListViewColumnSortArrow::Down),
             _ => None,
         }
     }
@@ -570,8 +570,8 @@ impl ListView {
 
             header.fmt &= !(HDF_SORTUP | HDF_SORTDOWN);
             match sort {
-                Some(ListViewColumnSortArrow::UP) => header.fmt |= HDF_SORTUP,
-                Some(ListViewColumnSortArrow::DOWN) => header.fmt |= HDF_SORTDOWN,
+                Some(ListViewColumnSortArrow::Up) => header.fmt |= HDF_SORTUP,
+                Some(ListViewColumnSortArrow::Down) => header.fmt |= HDF_SORTDOWN,
                 _ => {}
             };
 

--- a/native-windows-gui/src/controls/mod.rs
+++ b/native-windows-gui/src/controls/mod.rs
@@ -147,7 +147,7 @@ pub use tray_notification::{TrayNotificationFlags, TrayNotification, TrayNotific
 pub use message_window::{MessageWindow, MessageWindowBuilder};
 
 #[cfg(feature = "list-view")]
-pub use list_view::{ListView, ListViewStyle, ListViewBuilder, ListViewFlags, ListViewExFlags, InsertListViewItem, ListViewItem, InsertListViewColumn, ListViewColumn};
+pub use list_view::{ListView, ListViewStyle, ListViewBuilder, ListViewFlags, ListViewExFlags, InsertListViewItem, ListViewItem, InsertListViewColumn, ListViewColumn, ListViewColumnSortArrow};
 
 #[cfg(all(feature="list-view", feature="image-list"))]
 pub use list_view::ListViewImageListType;

--- a/native-windows-gui/src/tests/control_test.rs
+++ b/native-windows-gui/src/tests/control_test.rs
@@ -924,6 +924,11 @@ mod partial_controls_test_ui {
                         print_char(_evt_data);
                     }
                 },
+                E::OnListViewColumnClick => {
+                    if &handle == &self.test_list_view {
+                        set_lv_sort(&self.test_list_view, _evt_data);
+                    }
+                },
                 _ => {}
             }
         }
@@ -970,6 +975,7 @@ fn init_list_view(app: &ControlsTest) {
         list.insert_column(column);
     }
     list.set_headers_enabled(true);
+    list.set_column_sort_arrow(1, Some(ListViewColumnSortArrow::DOWN));
 
     let data: &[&[&str]] = &[
         // &["Name", "Price (USD $)", "Quantity"],
@@ -1596,5 +1602,23 @@ fn print_char(data: &EventData) {
     match data {
         EventData::OnChar(c) => println!("{:?}", c),
         _=>{}
+    }
+}
+
+fn set_lv_sort(lv: &ListView, data: &EventData) {
+    match data {
+        EventData::OnListViewItemIndex { row_index: _, column_index } => {
+            for i in 0..lv.column_len() {
+                if *column_index != i {
+                    lv.set_column_sort_arrow(i, None);
+                } else {
+                    match lv.column_sort_arrow(i) {
+                        Some(ListViewColumnSortArrow::UP) | None => lv.set_column_sort_arrow(i, Some(ListViewColumnSortArrow::DOWN)),
+                        Some(ListViewColumnSortArrow::DOWN) => lv.set_column_sort_arrow(i, Some(ListViewColumnSortArrow::UP)),
+                    }
+                }
+            }
+        },
+        _ => {}
     }
 }

--- a/native-windows-gui/src/tests/control_test.rs
+++ b/native-windows-gui/src/tests/control_test.rs
@@ -975,7 +975,7 @@ fn init_list_view(app: &ControlsTest) {
         list.insert_column(column);
     }
     list.set_headers_enabled(true);
-    list.set_column_sort_arrow(1, Some(ListViewColumnSortArrow::DOWN));
+    list.set_column_sort_arrow(1, Some(ListViewColumnSortArrow::Down));
 
     let data: &[&[&str]] = &[
         // &["Name", "Price (USD $)", "Quantity"],
@@ -1613,8 +1613,8 @@ fn set_lv_sort(lv: &ListView, data: &EventData) {
                     lv.set_column_sort_arrow(i, None);
                 } else {
                     match lv.column_sort_arrow(i) {
-                        Some(ListViewColumnSortArrow::UP) | None => lv.set_column_sort_arrow(i, Some(ListViewColumnSortArrow::DOWN)),
-                        Some(ListViewColumnSortArrow::DOWN) => lv.set_column_sort_arrow(i, Some(ListViewColumnSortArrow::UP)),
+                        Some(ListViewColumnSortArrow::Up) | None => lv.set_column_sort_arrow(i, Some(ListViewColumnSortArrow::Down)),
+                        Some(ListViewColumnSortArrow::Down) => lv.set_column_sort_arrow(i, Some(ListViewColumnSortArrow::Up)),
                     }
                 }
             }


### PR DESCRIPTION
Draws an up/down-arrow on list view headers. This is typically used to indicate that information in the current column is sorted in ascending/descending order