### PR TITLE
(Draft) Implement HasRawWindowHandle onto Window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ Cargo.lock
 code
 docs/native-windows-docs/tmp.*
 .vs
+
+# Exclude intellijank
+.idea

--- a/native-windows-gui/Cargo.toml
+++ b/native-windows-gui/Cargo.toml
@@ -24,7 +24,8 @@ lazy_static = "1.4.0"
 bitflags = { version = "1.1.0" }
 stretch = { version = "0.3.2", optional = true }
 muldiv = { version = "0.2", optional = true }
-
+# Integration for raw-window-handle
+raw-window-handle = { version = "0.3.3", optional = true }
 
 [dev-dependencies]
 native-windows-derive = { path = "../native-windows-derive/" }
@@ -70,6 +71,7 @@ tree-view-iterator = []
 dynamic_layout = []
 flexbox = ["stretch"]
 high-dpi = ["muldiv"]
+raw-win-handle = ["raw-window-handle"]
 all = ["file-dialog", "color-dialog", "font-dialog", "datetime-picker", "progress-bar", "timer", "notice", "list-view", "cursor", "image-decoder",
        "tabs", "tree-view", "fancy-window", "listbox", "combobox", "tray-notification", "message-window", "number-select", "clipboard", "menu",
        "trackbar", "extern-canvas", "frame", "tooltip", "status-bar", "winnls", "textbox", "rich-textbox", "image-list", "embed-resource", "scroll-bar",


### PR DESCRIPTION
This adds a feature to allow getting the raw window handle from [raw-window-handle](https://github.com/rust-windowing/raw-window-handle) from a `Window`.

This is completely untested and I am not sure this even compiles, so don't let the code get to you yet :) since I wrote this on Linux and will test on Windows probably tomorrow or Friday.

Integration with raw-window-handle is done via a feature which is not enabled by default, so users are not forced to use the raw-window-handle if they do not need it.

Main purpose for this feature is to allow libraries such as wgpu or anything which supports raw-window-handle to work with NWG.