### PR TITLE
Panic fix

### DIFF
--- a/native-windows-gui/src/controls/animation_timer.rs
+++ b/native-windows-gui/src/controls/animation_timer.rs
@@ -224,7 +224,7 @@ impl AnimationTimer {
         This resets the life time and tick count if relevant.
     */
     pub fn start(&self) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let (_, id) = self.handle.timer().expect(BAD_HANDLE);
         AnimationThread::reset_timer(id);
     }
@@ -233,28 +233,28 @@ impl AnimationTimer {
         Stop the selected timer. If the timer is already stopped, this does nothing.
     */
     pub fn stop(&self) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let (_, id) = self.handle.timer().expect(BAD_HANDLE);
         AnimationThread::stop_timer(id);
     }
 
     /// Sets the interval on the this timer
     pub fn set_interval(&self, i: Duration) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let (_, id) = self.handle.timer().expect(BAD_HANDLE);
         AnimationThread::update_timer(id, Some(i), None, None);
     }
 
     /// Sets the life time on the this timer
     pub fn set_lifetime(&self, life: Option<Duration>) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let (_, id) = self.handle.timer().expect(BAD_HANDLE);
         AnimationThread::update_timer(id, None, Some(life), None);
     }
 
     /// Sets the max tick count on the this timer
     pub fn set_max_tick(&self, max_tick: Option<u64>) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let (_, id) = self.handle.timer().expect(BAD_HANDLE);
         AnimationThread::update_timer(id, None, None, Some(max_tick));
     }

--- a/native-windows-gui/src/controls/check_box.rs
+++ b/native-windows-gui/src/controls/check_box.rs
@@ -274,7 +274,7 @@ impl CheckBox {
         use winapi::shared::{basetsd::UINT_PTR, windef::HWND, minwindef::LRESULT};
         use winapi::um::wingdi::{CreateSolidBrush, RGB};
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let parent_handle = ControlHandle::Hwnd(wh::get_window_parent(handle));

--- a/native-windows-gui/src/controls/combo_box.rs
+++ b/native-windows-gui/src/controls/combo_box.rs
@@ -416,7 +416,7 @@ impl<D: Display+Default> ComboBox<D> {
         use winapi::um::wingdi::{SelectObject, CreateSolidBrush, RGB};
         use std::ptr;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let brush = match bg {
             Some(c) => unsafe { CreateSolidBrush(RGB(c[0], c[1], c[2])) },
             None => COLOR_WINDOW as HBRUSH

--- a/native-windows-gui/src/controls/image_frame.rs
+++ b/native-windows-gui/src/controls/image_frame.rs
@@ -201,7 +201,7 @@ impl ImageFrame {
         use winapi::shared::{basetsd::UINT_PTR, windef::{HWND}, minwindef::LRESULT};
         use winapi::um::wingdi::{CreateSolidBrush, RGB};
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let parent_handle = ControlHandle::Hwnd(wh::get_window_parent(handle));

--- a/native-windows-gui/src/controls/label.rs
+++ b/native-windows-gui/src/controls/label.rs
@@ -216,7 +216,7 @@ impl Label {
         use winapi::um::wingdi::{SelectObject, CreateSolidBrush, RGB};
         use std::{mem, ptr};
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let parent_handle = ControlHandle::Hwnd(wh::get_window_parent(handle));

--- a/native-windows-gui/src/controls/menu.rs
+++ b/native-windows-gui/src/controls/menu.rs
@@ -110,11 +110,11 @@ impl Menu {
 
     /// Return true if the control user can interact with the control, return false otherwise
     pub fn enabled(&self) -> bool {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let (parent_handle, handle) = match self.handle {
             ControlHandle::Menu(parent, menu) => (parent, menu),
             ControlHandle::PopMenu(_, _) => { return true; },
-            _ => panic!(BAD_HANDLE)
+            _ => std::panic::panic_any(BAD_HANDLE)
         };
 
         unsafe { mh::is_menu_enabled(parent_handle, handle) }
@@ -123,11 +123,11 @@ impl Menu {
     /// Enable or disable the control
     /// A popup menu cannot be disabled
     pub fn set_enabled(&self, v: bool) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let (parent_handle, handle) = match self.handle {
             ControlHandle::Menu(parent, menu) => (parent, menu),
             ControlHandle::PopMenu(_, _) => { return; },
-            _ => panic!(BAD_HANDLE)
+            _ => std::panic::panic_any(BAD_HANDLE)
         };
 
         unsafe { mh::enable_menu(parent_handle, handle, v); }
@@ -271,7 +271,7 @@ impl MenuItem {
 
     /// Return true if the control user can interact with the control, return false otherwise
     pub fn enabled(&self) -> bool {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let (parent_handle, id) = self.handle.hmenu_item().expect(BAD_HANDLE);
         
         unsafe { mh::is_menuitem_enabled(parent_handle, None, Some(id)) }
@@ -279,7 +279,7 @@ impl MenuItem {
 
     /// Enable or disable the control
     pub fn set_enabled(&self, v: bool) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let (parent_handle, id) = self.handle.hmenu_item().expect(BAD_HANDLE);
 
         unsafe { mh::enable_menuitem(parent_handle, None, Some(id), v); }
@@ -287,7 +287,7 @@ impl MenuItem {
 
     /// Sets the check state of a menu item
     pub fn set_checked(&self, check: bool) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let (parent_handle, id) = self.handle.hmenu_item().expect(BAD_HANDLE);
 
         unsafe { mh::check_menu_item(parent_handle, id, check); }
@@ -295,7 +295,7 @@ impl MenuItem {
 
     /// Returns the check state of a menu item
     pub fn checked(&self) -> bool {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let (parent_handle, id) = self.handle.hmenu_item().expect(BAD_HANDLE);
 
         unsafe { mh::menu_item_checked(parent_handle, id) }

--- a/native-windows-gui/src/controls/notice.rs
+++ b/native-windows-gui/src/controls/notice.rs
@@ -87,7 +87,7 @@ impl Notice {
     /// Change the parent window of the notice. This won't update the NoticeSender already created.
     /// Panics if the control is not a window-like control or if the notice was not initialized
     pub fn set_window_handle<C: Into<ControlHandle>>(&mut self, window: C) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
 
         let hwnd = window.into().hwnd().expect("New notice parent is not a window control");
         let (_, id) = self.handle.notice().expect(BAD_HANDLE);
@@ -97,8 +97,8 @@ impl Notice {
 
     /// Create a new `NoticeSender` bound to this Notice
     pub fn sender(&self) -> NoticeSender {
-        if self.handle.blank() { panic!(NOT_BOUND); }
-        if !self.valid() { panic!(UNUSABLE_NOTICE); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
+        if !self.valid() { std::panic::panic_any(UNUSABLE_NOTICE); }
         let (hwnd, id) = self.handle.notice().expect(BAD_HANDLE);
 
         NoticeSender { 

--- a/native-windows-gui/src/controls/radio_button.rs
+++ b/native-windows-gui/src/controls/radio_button.rs
@@ -275,7 +275,7 @@ impl RadioButton {
         use winapi::shared::{basetsd::UINT_PTR, windef::{HWND}, minwindef::LRESULT};
         use winapi::um::wingdi::{CreateSolidBrush, RGB};
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let parent_handle = ControlHandle::Hwnd(wh::get_window_parent(handle));

--- a/native-windows-gui/src/controls/scroll_bar.rs
+++ b/native-windows-gui/src/controls/scroll_bar.rs
@@ -217,7 +217,7 @@ impl ScrollBar {
             GET_WHEEL_DELTA_WPARAM, SCROLLINFO, GetScrollInfo, SetScrollInfo};
         use winapi::shared::{minwindef::{TRUE, LOWORD}, windef::HWND};
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         let parent_handle = ControlHandle::Hwnd(wh::get_window_parent(handle));
 

--- a/native-windows-gui/src/controls/status_bar.rs
+++ b/native-windows-gui/src/controls/status_bar.rs
@@ -131,7 +131,7 @@ impl StatusBar {
         use winapi::um::winuser::WM_SIZE;
         use crate::bind_raw_event_handler_inner;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let parent_handle = ControlHandle::Hwnd(wh::get_window_parent(handle));

--- a/native-windows-gui/src/controls/tabs.rs
+++ b/native-windows-gui/src/controls/tabs.rs
@@ -256,7 +256,7 @@ impl TabsContainer {
         use winapi::um::commctrl::{TCM_GETCURSEL, TCN_SELCHANGE};
         use winapi::um::winuser::SendMessageW;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let parent_handle_raw = wh::get_window_parent(handle);
@@ -482,7 +482,7 @@ impl Tab {
         use winapi::um::commctrl::{TCM_SETITEMW, TCIF_TEXT, TCITEMW};
         use winapi::um::winuser::GWL_USERDATA;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let tab_index = (wh::get_window_long(handle, GWL_USERDATA) - 1) as WPARAM;
@@ -514,7 +514,7 @@ impl Tab {
         use winapi::um::commctrl::{TCM_SETITEMW, TCIF_IMAGE, TCITEMW};
         use winapi::um::winuser::GWL_USERDATA;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let tab_index = (wh::get_window_long(handle, GWL_USERDATA) - 1) as WPARAM;
@@ -548,14 +548,14 @@ impl Tab {
     /// Returns true if the control is visible to the user. Will return true even if the 
     /// control is outside of the parent client view (ex: at the position (10000, 10000))
     pub fn visible(&self) -> bool {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::get_window_visibility(handle) }
     }
 
     /// Show or hide the control to the user
     pub fn set_visible(&self, v: bool) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::set_window_visibility(handle, v) }
     }
@@ -622,7 +622,7 @@ impl Tab {
     fn bind_container<'a>(&self, text: &'a str) {
         use winapi::um::commctrl::{TCITEMW, TCM_INSERTITEMW, TCIF_TEXT};
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let tab_view_handle = wh::get_window_parent(handle);

--- a/native-windows-gui/src/controls/text_box.rs
+++ b/native-windows-gui/src/controls/text_box.rs
@@ -97,7 +97,7 @@ impl TextBox {
 
     /// Return the font of the control
     pub fn font(&self) -> Option<Font> {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let font_handle = wh::get_window_font(handle);
@@ -110,7 +110,7 @@ impl TextBox {
 
     /// Set the font of the control
     pub fn set_font(&self, font: Option<&Font>) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::set_window_font(handle, font.map(|f| f.handle), true); }
     }
@@ -119,7 +119,7 @@ impl TextBox {
     pub fn limit(&self) -> u32 {
         use winapi::um::winuser::EM_GETLIMITTEXT;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         wh::send_message(handle, EM_GETLIMITTEXT as u32, 0, 0) as u32
@@ -129,7 +129,7 @@ impl TextBox {
     pub fn set_limit(&self, limit: usize) {
         use winapi::um::winuser::EM_SETLIMITTEXT;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         wh::send_message(handle, EM_SETLIMITTEXT as u32, limit, 0);
@@ -139,7 +139,7 @@ impl TextBox {
     pub fn modified(&self) -> bool {
         use winapi::um::winuser::EM_GETMODIFY;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         wh::send_message(handle, EM_GETMODIFY as u32, 0, 0) != 0
@@ -148,7 +148,7 @@ impl TextBox {
     /// Manually set modified flag of the text input
     pub fn set_modified(&self, e: bool) {
         use winapi::um::winuser::EM_SETMODIFY;
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         wh::send_message(handle, EM_SETMODIFY as u32, e as usize, 0);
@@ -158,7 +158,7 @@ impl TextBox {
     pub fn undo(&self) {
         use winapi::um::winuser::EM_UNDO;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         wh::send_message(handle, EM_UNDO as u32, 0, 0);
@@ -168,7 +168,7 @@ impl TextBox {
     pub fn selection(&self) -> Range<u32> {
         use winapi::um::winuser::EM_GETSEL;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let (mut out1, mut out2) = (0u32, 0u32);
@@ -182,7 +182,7 @@ impl TextBox {
     pub fn set_selection(&self, r: Range<u32>) {
         use winapi::um::winuser::EM_SETSEL;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         wh::send_message(handle, EM_SETSEL as u32, r.start as usize, r.end as isize);
     }
@@ -191,7 +191,7 @@ impl TextBox {
     /// does not allocate a string in memory
     pub fn len(&self) -> u32 {
         use winapi::um::winuser::EM_LINELENGTH;
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         wh::send_message(handle, EM_LINELENGTH as u32, 0, 0) as u32
@@ -202,7 +202,7 @@ impl TextBox {
     pub fn readonly(&self) -> bool {
         use winapi::um::winuser::ES_READONLY;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         wh::get_style(handle) & ES_READONLY == ES_READONLY
     }
@@ -212,7 +212,7 @@ impl TextBox {
     pub fn set_readonly(&self, r: bool) {
         use winapi::um::winuser::EM_SETREADONLY;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         wh::send_message(handle, EM_SETREADONLY as u32, r as WPARAM, 0);
     }
@@ -224,28 +224,28 @@ impl TextBox {
 
     /// Return true if the control currently has the keyboard focus
     pub fn focus(&self) -> bool {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::get_focus(handle) }
     }
 
     /// Set the keyboard focus on the button
     pub fn set_focus(&self) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::set_focus(handle); }
     }
 
     /// Return true if the control user can interact with the control, return false otherwise
     pub fn enabled(&self) -> bool {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::get_window_enabled(handle) }
     }
 
     /// Enable or disable the control
     pub fn set_enabled(&self, v: bool) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::set_window_enabled(handle, v) }
     }
@@ -253,56 +253,56 @@ impl TextBox {
     /// Return true if the control is visible to the user. Will return true even if the 
     /// control is outside of the parent client view (ex: at the position (10000, 10000))
     pub fn visible(&self) -> bool {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::get_window_visibility(handle) }
     }
 
     /// Show or hide the control to the user
     pub fn set_visible(&self, v: bool) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::set_window_visibility(handle, v) }
     }
 
     /// Return the size of the button in the parent window
     pub fn size(&self) -> (u32, u32) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::get_window_size(handle) }
     }
 
     /// Set the size of the button in the parent window
     pub fn set_size(&self, x: u32, y: u32) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::set_window_size(handle, x, y, false) }
     }
 
     /// Return the position of the button in the parent window
     pub fn position(&self) -> (i32, i32) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::get_window_position(handle) }
     }
 
     /// Set the position of the button in the parent window
     pub fn set_position(&self, x: i32, y: i32) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::set_window_position(handle, x, y) }
     }
 
     /// Return the text displayed in the TextInput
     pub fn text(&self) -> String { 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::get_window_text(handle) }
     }
 
     /// Set the text displayed in the TextInput
     pub fn set_text<'a>(&self, v: &'a str) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         unsafe { wh::set_window_text(handle, v) }
     }

--- a/native-windows-gui/src/controls/text_input.rs
+++ b/native-windows-gui/src/controls/text_input.rs
@@ -364,7 +364,7 @@ impl TextInput {
         use winapi::um::wingdi::{SelectObject, CreateSolidBrush, RGB};
         use std::{mem, ptr};
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         self.handle.hwnd().expect(BAD_HANDLE);
 
         let brush = match bg {

--- a/native-windows-gui/src/controls/timer.rs
+++ b/native-windows-gui/src/controls/timer.rs
@@ -86,8 +86,8 @@ impl Timer {
 
     /// Stops the timer.
     pub fn stop(&self) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
-        if !self.valid() { panic!(UNUSABLE_TIMER); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
+        if !self.valid() { std::panic::panic_any(UNUSABLE_TIMER); }
         let (hwnd, id) = self.handle.timer().expect(BAD_HANDLE);
 
         wh::kill_timer(hwnd, id);
@@ -95,8 +95,8 @@ impl Timer {
 
     /// Starts the timer. If the timer is already running, this restarts it.
     pub fn start(&self) {
-        if self.handle.blank() { panic!(NOT_BOUND); }
-        if !self.valid() { panic!(UNUSABLE_TIMER); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
+        if !self.valid() { std::panic::panic_any(UNUSABLE_TIMER); }
         let (hwnd, id) = self.handle.timer().expect(BAD_HANDLE);
 
         wh::start_timer(hwnd, id, self.interval());

--- a/native-windows-gui/src/controls/tooltip.rs
+++ b/native-windows-gui/src/controls/tooltip.rs
@@ -147,7 +147,7 @@ impl Tooltip {
         let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
 
         let owner_handle = {
-            if owner.blank() { panic!(NOT_BOUND); }
+            if owner.blank() { std::panic::panic_any(NOT_BOUND); }
             owner.hwnd().expect(BAD_HANDLE)
         };
 
@@ -183,7 +183,7 @@ impl Tooltip {
 
         let mut text = to_utf16(text);
         let owner_handle = {
-            if owner.blank() { panic!(NOT_BOUND); }
+            if owner.blank() { std::panic::panic_any(NOT_BOUND); }
             owner.hwnd().expect(BAD_HANDLE)
         };
 
@@ -293,7 +293,7 @@ impl Tooltip {
 
         let mut text = to_utf16(text);
         let owner_handle = {
-            if owner.blank() { panic!(NOT_BOUND); }
+            if owner.blank() { std::panic::panic_any(NOT_BOUND); }
             owner.hwnd().expect(BAD_HANDLE)
         };
 
@@ -324,7 +324,7 @@ impl Tooltip {
 
         let owner = owner.into();
         let owner_handle = {
-            if owner.blank() { panic!(NOT_BOUND); }
+            if owner.blank() { std::panic::panic_any(NOT_BOUND); }
             owner.hwnd().expect(BAD_HANDLE)
         };
 
@@ -353,7 +353,7 @@ impl Tooltip {
         let owner = owner.into();
 
         let owner_handle = {
-            if owner.blank() { panic!(NOT_BOUND); }
+            if owner.blank() { std::panic::panic_any(NOT_BOUND); }
             owner.hwnd().expect(BAD_HANDLE)
         };
 

--- a/native-windows-gui/src/controls/tooltip.rs
+++ b/native-windows-gui/src/controls/tooltip.rs
@@ -110,7 +110,7 @@ impl Tooltip {
         use winapi::um::commctrl::{TTGETTITLE, TTM_GETTITLE};
         use winapi::um::commctrl::{TTI_NONE, TTI_INFO, TTI_WARNING, TTI_ERROR, TTI_INFO_LARGE, TTI_WARNING_LARGE, TTI_ERROR_LARGE};
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let mut tt = TTGETTITLE {

--- a/native-windows-gui/src/controls/track_bar.rs
+++ b/native-windows-gui/src/controls/track_bar.rs
@@ -279,7 +279,7 @@ impl TrackBar {
         use winapi::shared::{basetsd::UINT_PTR, windef::{HWND}, minwindef::LRESULT};
         use winapi::um::wingdi::{CreateSolidBrush, RGB};
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
 
         let parent_handle = ControlHandle::Hwnd(wh::get_window_parent(handle));

--- a/native-windows-gui/src/controls/tray_notification.rs
+++ b/native-windows-gui/src/controls/tray_notification.rs
@@ -106,7 +106,7 @@ impl TrayNotification {
     pub fn set_visibility(&self, v: bool) {
         use winapi::um::shellapi::{NIF_STATE, NIM_MODIFY, NIS_HIDDEN};  
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         self.handle.tray().expect(BAD_HANDLE);
 
         unsafe {
@@ -123,7 +123,7 @@ impl TrayNotification {
     pub fn set_tip<'a>(&self, tip: &'a str) {
         use winapi::um::shellapi::{NIM_MODIFY, NIF_TIP, NIF_SHOWTIP};  
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         self.handle.tray().expect(BAD_HANDLE);
 
         unsafe {
@@ -145,7 +145,7 @@ impl TrayNotification {
     pub fn set_focus(&self) {
         use winapi::um::shellapi::{NIM_SETFOCUS};
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         self.handle.tray().expect(BAD_HANDLE);
 
         unsafe {
@@ -159,7 +159,7 @@ impl TrayNotification {
         use winapi::um::shellapi::{NIF_ICON, NIM_MODIFY};
         use winapi::shared::windef::HICON;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         self.handle.tray().expect(BAD_HANDLE);
 
         unsafe {
@@ -185,7 +185,7 @@ impl TrayNotification {
         use winapi::um::shellapi::{NIF_INFO, NIM_MODIFY};
         use winapi::shared::windef::HICON;
 
-        if self.handle.blank() { panic!(NOT_BOUND); }
+        if self.handle.blank() { std::panic::panic_any(NOT_BOUND); }
         self.handle.tray().expect(BAD_HANDLE);
 
         let default_flags = TrayNotificationFlags::NO_ICON | TrayNotificationFlags::SILENT;

--- a/native-windows-gui/src/controls/treeview.rs
+++ b/native-windows-gui/src/controls/treeview.rs
@@ -799,7 +799,7 @@ impl Eq for TreeItem {}
 fn next_treeview_item(handle: &ControlHandle, action: usize, item: HTREEITEM) -> Option<TreeItem> {
     use winapi::um::commctrl::TVM_GETNEXTITEM;
 
-    if handle.blank() { panic!(NOT_BOUND); }
+    if handle.blank() { std::panic::panic_any(NOT_BOUND); }
     let handle = handle.hwnd().expect(BAD_HANDLE);
 
     let handle = wh::send_message(handle, TVM_GETNEXTITEM, action as _, item as _) as HTREEITEM;

--- a/native-windows-gui/src/resources/image_list.rs
+++ b/native-windows-gui/src/resources/image_list.rs
@@ -50,7 +50,7 @@ impl ImageList {
     pub fn size(&self) -> (i32, i32) {
         use winapi::um::commctrl::ImageList_GetIconSize;
 
-        if self.handle.is_null() { panic!(NOT_BOUND); }
+        if self.handle.is_null() { std::panic::panic_any(NOT_BOUND); }
 
         let mut size = (0, 0);
         unsafe { ImageList_GetIconSize(self.handle, &mut size.0, &mut size.1); }
@@ -62,7 +62,7 @@ impl ImageList {
     pub fn set_size(&self, size: (i32, i32)) {
         use winapi::um::commctrl::ImageList_SetIconSize;
 
-        if self.handle.is_null() { panic!(NOT_BOUND); }
+        if self.handle.is_null() { std::panic::panic_any(NOT_BOUND); }
 
         let (w, h) = size;
         unsafe { ImageList_SetIconSize(self.handle, w, h); }
@@ -72,14 +72,14 @@ impl ImageList {
     pub fn len(&self) -> u32 {
         use winapi::um::commctrl::ImageList_GetImageCount;
 
-        if self.handle.is_null() { panic!(NOT_BOUND); }
+        if self.handle.is_null() { std::panic::panic_any(NOT_BOUND); }
 
         unsafe { ImageList_GetImageCount(self.handle) as u32 }
     }
 
     /// Adds a new bitmap to the image list. Returns the index to the image. Panics if the bitmap was not initialized
     pub fn add_bitmap(&self, bitmap: &Bitmap) -> i32 {
-        if self.handle.is_null() { panic!(NOT_BOUND); }
+        if self.handle.is_null() { std::panic::panic_any(NOT_BOUND); }
         if bitmap.handle.is_null() { panic!("Bitmap was not initialized"); }
 
         unsafe { ImageList_AddMasked(self.handle, bitmap.handle as HBITMAP, 0) }
@@ -90,7 +90,7 @@ impl ImageList {
         Returns the index to the image or an error if the image could not be loaded
     */
     pub fn add_bitmap_from_filename(&self, filename: &str) -> Result<i32, NwgError> {
-        if self.handle.is_null() { panic!(NOT_BOUND); }
+        if self.handle.is_null() { std::panic::panic_any(NOT_BOUND); }
 
         let (w, h) = self.size();
         let mut bitmap = Bitmap::default();
@@ -108,7 +108,7 @@ impl ImageList {
         use winapi::um::winuser::{GetIconInfo, ICONINFO};
         use winapi::um::wingdi::DeleteObject;
 
-        if self.handle.is_null() { panic!(NOT_BOUND); }
+        if self.handle.is_null() { std::panic::panic_any(NOT_BOUND); }
         if icon.handle.is_null() { panic!("Icon was not initialized"); }
 
         // Extract the bitmap from the icon
@@ -131,7 +131,7 @@ impl ImageList {
         Returns the index to the image or an error if the image could not be loaded
     */
     pub fn add_icon_from_filename(&self, filename: &str) -> Result<i32, NwgError> {
-        if self.handle.is_null() { panic!(NOT_BOUND); }
+        if self.handle.is_null() { std::panic::panic_any(NOT_BOUND); }
 
         let (w, h) = self.size();
         let mut icon = Icon::default();
@@ -154,7 +154,7 @@ impl ImageList {
     pub fn remove(&self, index: i32) {
         use winapi::um::commctrl::ImageList_Remove;
 
-        if self.handle.is_null() { panic!(NOT_BOUND); }
+        if self.handle.is_null() { std::panic::panic_any(NOT_BOUND); }
 
         unsafe { ImageList_Remove(self.handle, index); }
     }
@@ -163,7 +163,7 @@ impl ImageList {
     pub fn replace_bitmap(&self, index: i32, bitmap: &Bitmap) {
         use winapi::um::commctrl::ImageList_Replace;
 
-        if self.handle.is_null() { panic!(NOT_BOUND); }
+        if self.handle.is_null() { std::panic::panic_any(NOT_BOUND); }
         if bitmap.handle.is_null() { panic!("Bitmap was not initialized"); }
         
         unsafe { ImageList_Replace(self.handle, index, bitmap.handle as HBITMAP, ptr::null_mut()); }
@@ -173,7 +173,7 @@ impl ImageList {
     pub fn replace_icon(&self, index: i32, icon: &Icon) {
         use winapi::um::commctrl::ImageList_ReplaceIcon;
 
-        if self.handle.is_null() { panic!(NOT_BOUND); }
+        if self.handle.is_null() { std::panic::panic_any(NOT_BOUND); }
         if icon.handle.is_null() { panic!("Icon was not initialized"); }
 
         unsafe { ImageList_ReplaceIcon(self.handle, index, icon.handle as HICON); }

--- a/native-windows-gui/src/win32/cursor.rs
+++ b/native-windows-gui/src/win32/cursor.rs
@@ -42,7 +42,7 @@ impl GlobalCursor {
         const MSG: &'static str = "local_position can only be used for window control";
 
         let control = control.into();
-        if control.blank() { panic!(MSG); }
+        if control.blank() { std::panic::panic_any(MSG); }
         let handle = control.hwnd().expect(MSG);
 
         let (x, y) = point.unwrap_or(GlobalCursor::position());
@@ -114,7 +114,7 @@ impl GlobalCursor {
         use winapi::um::winuser::SetCapture;
         const MSG: &'static str = "Mouse capture can only be set for window control";
 
-        if control.blank() { panic!(MSG); }
+        if control.blank() { std::panic::panic_any(MSG); }
         let handle = control.hwnd().expect(MSG);
 
         unsafe { SetCapture(handle); }
@@ -172,7 +172,7 @@ impl GlobalCursor {
 
         const MSG: &'static str = "Dragging can only be set for window control";
 
-        if control.blank() { panic!(MSG); }
+        if control.blank() { std::panic::panic_any(MSG); }
         let handle = control.hwnd().expect(MSG);
 
         let (x, y) = point.unwrap_or(GlobalCursor::position());


### PR DESCRIPTION
Rust 2021 gives warnings when using panic! with the const &'static str messages that are liberally used in the codebase.  This fix eliminates over 70 warnings.