### PR TITLE
Fixed link URL

### DIFF
--- a/docs/native-windows-docs/controls.html
+++ b/docs/native-windows-docs/controls.html
@@ -146,7 +146,7 @@
         Most controls in NWG cannot hold children. Those that can are called "container controls". This includes <b>Window</b>, <b>Tab Container</b>,
         and <b>Tab</b>. TabContainer should only contains tab controls.<br><br>
 
-        Container controls can also use <b>layouts</b>. More on that in <a href="file:///C:/Users/Gab/Documents/projects/native-windows-gui/native-windows-docs/layouts.html">the layout section</a>
+        Container controls can also use <b>layouts</b>. More on that in <a href="layouts.html">the layout section</a>
         <br><br>
 
         The window control is be the base of any GUI application. It represents a top level system window. Every NWG application will have a window.


### PR DESCRIPTION
As I was browsing the docs I found this broken link that must have been to your local clone. It's now linked relatively so it works online, but should still work in your local version.