### PR TITLE
Support for nested flexboxes

### DIFF
--- a/native-windows-gui/src/layouts/flexbox_layout.rs
+++ b/native-windows-gui/src/layouts/flexbox_layout.rs
@@ -488,10 +488,7 @@ impl FlexboxLayoutBuilder {
 
         let index = self.current_index.unwrap();
 
-        match &mut self.layout.children[index] {
-            FlexboxLayoutChild::Item(item) => fnc(&mut item.style),
-            FlexboxLayoutChild::Flexbox(flex) => fnc(&mut flex.inner.borrow_mut().style),
-        }
+        self.layout.children[index].modify_style(|s| fnc(s));
     }
 
     /// Build the layout object and bind the callback.


### PR DESCRIPTION
Basic support for nested flexboxes, mostly through changing style modification style (unification between item and layout subitems).

This required adding a new child_layout functionality to prevent sub-layouts from registering their own callbacks. Sublayout are thus only recalculated when the parent layout is recalculated.

Happy to change or explain anything if required!