### PR TITLE
Add scrolling support to TextBox

### DIFF
--- a/native-windows-gui/Cargo.toml
+++ b/native-windows-gui/Cargo.toml
@@ -22,7 +22,7 @@ winapi = { version = "0.3", features = [
 
 lazy_static = "1.4.0"
 bitflags = "1.1.0"
-newline-converter = "0.2.0"
+newline-converter = { version = "0.2.0", optional = true }
 stretch = { version = "0.3.2", optional = true }
 muldiv = { version = "0.2", optional = true }
 plotters = { version = "0.3", optional = true, default-features=false, features=["all_series", "all_elements"] }
@@ -66,8 +66,8 @@ frame = []
 tooltip = []
 status-bar = []
 winnls = []
-textbox = []
-rich-textbox = []
+textbox = ["newline-converter"]
+rich-textbox = ["newline-converter"]
 image-list = []
 no-styling = []
 embed-resource = []

--- a/native-windows-gui/Cargo.toml
+++ b/native-windows-gui/Cargo.toml
@@ -22,6 +22,7 @@ winapi = { version = "0.3", features = [
 
 lazy_static = "1.4.0"
 bitflags = "1.1.0"
+newline-converter = "0.2.0"
 stretch = { version = "0.3.2", optional = true }
 muldiv = { version = "0.2", optional = true }
 plotters = { version = "0.3", optional = true, default-features=false, features=["all_series", "all_elements"] }

--- a/native-windows-gui/examples/echo_d.rs
+++ b/native-windows-gui/examples/echo_d.rs
@@ -89,7 +89,7 @@ impl EchoApp {
     }
 
     pub fn scroll_to_bot(&self) {
-        self.text.scroll(self.text.linecount());
+        self.text.scroll_lastline();
     }
 
     pub fn submit(&self) {

--- a/native-windows-gui/examples/echo_d.rs
+++ b/native-windows-gui/examples/echo_d.rs
@@ -1,0 +1,108 @@
+/*!
+    Small example that shows how to scroll and append text to a text box
+*/
+
+extern crate native_windows_gui as nwg;
+extern crate native_windows_derive as nwd;
+
+use nwd::NwgUi;
+use nwg::NativeUi;
+use std::fs;
+
+#[derive(Default, NwgUi)]
+pub struct EchoApp {
+    #[nwg_control(size: (1000, 420), position: (300, 300), title: "Echo", accept_files: true)]
+    #[nwg_events( 
+        OnInit: [EchoApp::init_text],
+        OnWindowClose: [nwg::stop_thread_dispatch()], 
+        OnFileDrop: [EchoApp::load_text(SELF, EVT_DATA)], 
+        OnKeyEnter: [EchoApp::submit], 
+    )]
+    window: nwg::Window,
+
+    #[nwg_layout(parent: window, spacing: 1)]
+    grid: nwg::GridLayout,
+
+    #[nwg_control(text:"Loading...\r\n", readonly: true)]
+    #[nwg_layout_item(layout: grid, col: 0, row: 0, col_span: 7, row_span: 4)]
+    text: nwg::TextBox,
+
+    #[nwg_control(focus: true)]
+    #[nwg_layout_item(layout: grid, col: 0, row: 4, col_span: 7)]
+    text_input: nwg::TextInput,
+
+
+    #[nwg_control(text: "Clear")]
+    #[nwg_layout_item(layout: grid, col: 7, row: 0)]
+    #[nwg_events( OnButtonClick: [EchoApp::clear] )]
+    b1: nwg::Button,
+    #[nwg_control(text: "Scroll Top")]
+    #[nwg_layout_item(layout: grid, col: 7, row: 1)]
+    #[nwg_events( OnButtonClick: [EchoApp::scroll_to_top] )]
+    b2: nwg::Button,
+    #[nwg_control(text: "Scroll Mid")]
+    #[nwg_layout_item(layout: grid, col: 7, row: 2)]
+    #[nwg_events( OnButtonClick: [EchoApp::scroll_to_mid] )]
+    b3: nwg::Button,
+    #[nwg_control(text: "Scroll Bot")]
+    #[nwg_layout_item(layout: grid, col: 7, row: 3)]
+    #[nwg_events( OnButtonClick: [EchoApp::scroll_to_bot] )]
+    b4: nwg::Button,
+    #[nwg_control(text: "Submit")]
+    #[nwg_layout_item(layout: grid, col: 7, row: 4)]
+    #[nwg_events( OnButtonClick: [EchoApp::submit] )]
+    b5: nwg::Button,
+}
+
+impl EchoApp {
+    pub fn load_text(&self, data: &nwg::EventData) {
+        let drop = data.on_file_drop();
+
+        let mut text = String::with_capacity(1000);
+
+        for file in drop.files() {
+            text.push_str(&fs::read_to_string(file).unwrap_or("Invalid file".into()));
+        }
+        
+        self.text.appendln(&text);
+    }
+
+    pub fn init_text(&self) {
+        self.text.set_text_unix2dos("This text box will echo any text submitted below.\n");
+        self.text.append("Printing lines 2-256 to demo scrolling: ");
+        for i in 2..257 { 
+            self.text.appendln(&format!("{}", i));
+        }
+    }
+
+    pub fn clear(&self) {
+        self.text.clear();
+    }
+
+    pub fn scroll_to_top(&self) {
+        self.text.scroll(self.text.linecount() * -1);
+    }
+
+    pub fn scroll_to_mid(&self) {
+        self.scroll_to_top();
+        self.text.scroll(self.text.linecount() / 2);
+    }
+
+    pub fn scroll_to_bot(&self) {
+        self.text.scroll(self.text.linecount());
+    }
+
+    pub fn submit(&self) {
+        self.text.appendln(&self.text_input.text());
+        self.text_input.set_text("");
+    }
+}
+
+fn main() {
+    nwg::init().expect("Failed to init Native Windows GUI");
+    nwg::Font::set_global_family("Courier New").expect("Failed to set default font");
+
+    let _app = EchoApp::build_ui(Default::default()).expect("Failed to build UI");
+
+    nwg::dispatch_thread_events();
+}

--- a/native-windows-gui/examples/echo_richtext_d.rs
+++ b/native-windows-gui/examples/echo_richtext_d.rs
@@ -1,0 +1,177 @@
+/*!
+    Small example that shows how to append text to a rich text box with styling
+*/
+
+extern crate native_windows_gui as nwg;
+extern crate native_windows_derive as nwd;
+
+use nwd::NwgUi;
+use nwg::NativeUi;
+use std::fs;
+use std::cell::RefCell;
+
+#[derive(Default)]
+pub struct StyleSection {
+    start: u32,
+    end: u32,
+    char_format: Option<nwg::CharFormat>,
+    para_format: Option<nwg::ParaFormat>,
+}
+
+#[derive(Default, NwgUi)]
+pub struct EchoApp {
+    #[nwg_control(size: (1000, 420), position: (300, 300), title: "Echo", accept_files: true)]
+    #[nwg_events( 
+        OnInit: [EchoApp::init_text],
+        OnWindowClose: [nwg::stop_thread_dispatch()], 
+        OnFileDrop: [EchoApp::load_text(SELF, EVT_DATA)], 
+        OnKeyEnter: [EchoApp::submit], 
+    )]
+    window: nwg::Window,
+
+    #[nwg_layout(parent: window, spacing: 1)]
+    grid: nwg::GridLayout,
+
+    #[nwg_resource(family: "Segoe UI", size: 18)]
+    font: nwg::Font,
+
+    #[nwg_control(font: Some(&data.font), readonly: true, flags: "VSCROLL|HSCROLL|AUTOVSCROLL|VISIBLE|TAB_STOP|SAVE_SELECTION")]
+    #[nwg_layout_item(layout: grid, row: 0, col: 0, col_span: 7, row_span: 4)]
+    rich_text_box: nwg::RichTextBox,
+
+    #[nwg_control(focus: true)]
+    #[nwg_layout_item(layout: grid, col: 0, row: 4, col_span: 7)]
+    text_input: nwg::TextInput,
+
+    #[nwg_control(text: "Clear")]
+    #[nwg_layout_item(layout: grid, col: 7, row: 0, col_span: 2)]
+    #[nwg_events( OnButtonClick: [EchoApp::clear] )]
+    b1: nwg::Button,
+    #[nwg_control(text: "Underline")]
+    #[nwg_layout_item(layout: grid, col: 7, row: 1, col_span: 2)]
+    #[nwg_events( OnButtonClick: [EchoApp::underline] )]
+    b2: nwg::Button,
+    #[nwg_control(text: "Bullet")]
+    #[nwg_layout_item(layout: grid, col: 7, row: 2, col_span: 2)]
+    #[nwg_events( OnButtonClick: [EchoApp::bullet] )]
+    b3: nwg::Button,
+    #[nwg_control(text: "Header")]
+    #[nwg_layout_item(layout: grid, col: 7, row: 3, col_span: 2)]
+    #[nwg_events( OnButtonClick: [EchoApp::header] )]
+    b4: nwg::Button,
+    #[nwg_control(text: "Submit")]
+    #[nwg_layout_item(layout: grid, col: 7, row: 4, col_span: 2)]
+    #[nwg_events( OnButtonClick: [EchoApp::submit] )]
+    b5: nwg::Button,
+
+    style_sections: RefCell<Vec<StyleSection>>,
+}
+
+impl EchoApp {
+    pub fn load_text(&self, data: &nwg::EventData) {
+        let drop = data.on_file_drop();
+
+        let mut text = String::with_capacity(1000);
+
+        for file in drop.files() {
+            text.push_str(&fs::read_to_string(file).unwrap_or("Invalid file".into()));
+        }
+        
+        self.rich_text_box.appendln(&text);
+        self.apply_styles();
+    }
+
+    pub fn init_text(&self) {
+        self.rich_text_box.set_text_unix2dos("Each button on the right does one of the following:\n");
+        self.rich_text_box.append("\r\nClears the rich text box, removing all text and associated formatting.\r\n");
+        self.text_input.set_text("Echoes the text in the input box with underline styling.");
+        self.underline();
+        self.text_input.set_text("Echoes the text in the input box as a bullet point.");
+        self.bullet();
+        self.text_input.set_text("Echoes the text in the input box with header styling.");
+        self.header();
+        self.text_input.set_text("Echoes the text in the input box with no styling.");
+        self.submit();
+    }
+
+    pub fn clear(&self) {
+        self.rich_text_box.clear();
+        self.style_sections.borrow_mut().clear();
+    }
+
+    pub fn underline(&self) {
+        let mut style_section = StyleSection { start: self.rich_text_box.len(), ..Default::default()};
+        style_section.char_format = Some(nwg::CharFormat {
+            effects: Some(nwg::CharEffects::UNDERLINE),
+            ..Default::default()
+        });
+        self.rich_text_box.appendln(&self.text_input.text());
+        style_section.end = self.rich_text_box.len();
+        self.style_sections.borrow_mut().push(style_section);
+        self.text_input.set_text("");
+        self.apply_styles();
+    }
+
+    pub fn bullet(&self) {
+        let mut style_section = StyleSection { start: self.rich_text_box.len(), ..Default::default()};
+        style_section.para_format = Some(nwg::ParaFormat {
+            start_indent: Some(300),
+            right_indent: Some(300),
+            line_spacing: Some(nwg::ParaLineSpacing::Double),
+            numbering: Some(nwg::ParaNumbering::Bullet),
+            numbering_tab: Some(200),
+            ..Default::default()
+        });
+        self.rich_text_box.appendln(&self.text_input.text());
+        style_section.end = self.rich_text_box.len();
+        self.style_sections.borrow_mut().push(style_section);
+        self.text_input.set_text("");
+        self.apply_styles();
+    }
+
+    pub fn header(&self) {
+        let mut style_section = StyleSection { start: self.rich_text_box.len(), ..Default::default()};
+        style_section.char_format = Some(nwg::CharFormat {
+            effects: Some(nwg::CharEffects::BOLD | nwg::CharEffects::ITALIC),
+            height: Some(350),
+            text_color: Some([150, 50, 50]),
+            ..Default::default()
+        });
+        style_section.para_format = Some(nwg::ParaFormat {
+            alignment: Some(nwg::ParaAlignment::Center),
+            ..Default::default()
+        });
+        self.rich_text_box.appendln(&self.text_input.text());
+        style_section.end = self.rich_text_box.len();
+        self.style_sections.borrow_mut().push(style_section);
+        self.text_input.set_text("");
+        self.apply_styles();
+    }
+
+    pub fn apply_styles(&self){
+        for style_section in self.style_sections.borrow().iter() {   
+            self.rich_text_box.set_selection(style_section.start..style_section.end);
+            if let Some(p) = &style_section.para_format {
+                self.rich_text_box.set_para_format(p);
+            }
+            if let Some(c) = &style_section.char_format {
+                self.rich_text_box.set_char_format(c);
+            }
+        }
+    }
+
+    pub fn submit(&self) {
+        self.rich_text_box.appendln(&self.text_input.text());
+        self.text_input.set_text("");
+        self.apply_styles();
+    }
+}
+
+fn main() {
+    nwg::init().expect("Failed to init Native Windows GUI");
+    nwg::Font::set_global_family("Courier New").expect("Failed to set default font");
+
+    let _app = EchoApp::build_ui(Default::default()).expect("Failed to build UI");
+
+    nwg::dispatch_thread_events();
+}

--- a/native-windows-gui/src/controls/rich_text_box.rs
+++ b/native-windows-gui/src/controls/rich_text_box.rs
@@ -6,6 +6,7 @@ use crate::win32::richedit as rich;
 use crate::{Font, NwgError};
 use super::{ControlBase, ControlHandle};
 use std::ops::Range;
+use newline_converter::{unix2dos, dos2unix};
 
 const NOT_BOUND: &'static str = "RichTextBox is not yet bound to a winapi object";
 const BAD_HANDLE: &'static str = "INTERNAL ERROR: RichTextBox handle is not HWND!";
@@ -379,13 +380,36 @@ impl RichTextBox {
         wh::send_message(handle, EM_SETSEL as u32, r.start as usize, r.end as isize);
     }
 
-    /// Return the length of the user input in the control. This is better than `control.text().len()` as it
-    /// does not allocate a string in memory
+    /// Return the length of the user input in the control. Performs a newline conversion first since
+    /// Windows treats "\r\n" as a single character
     pub fn len(&self) -> u32 {
-        use winapi::um::winuser::EM_LINELENGTH;
+        use std::convert::TryInto;
+
+        dos2unix(&self.text()).chars().count().try_into().unwrap_or_default()
+    }
+    
+    /// Return the number of lines in the multiline edit control.
+    /// If the control has no text, the return value is 1.
+    pub fn linecount(&self) -> i32 {
+        use winapi::um::winuser::EM_GETLINECOUNT;
 
         let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
-        wh::send_message(handle, EM_LINELENGTH as u32, 0, 0) as u32
+        wh::send_message(handle, EM_GETLINECOUNT as u32, 0, 0) as i32
+    }  
+    
+    /// Scroll `v` lines in the multiline edit control.
+    pub fn scroll(&self, v: i32) {
+        use winapi::um::winuser::EM_LINESCROLL;
+        
+        let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
+        wh::send_message(handle, EM_LINESCROLL as u32, 0, v as LPARAM);
+    }
+    
+    /// Get the linecount and then scroll the text to the last line
+    pub fn scroll_lastline(&self) {
+        let lines = self.linecount();
+        self.scroll(lines * -1);
+        self.scroll(lines - 2);
     }
 
     /// Return true if the TextInput value cannot be edited. Retrurn false otherwise.
@@ -482,6 +506,26 @@ impl RichTextBox {
     pub fn set_text<'a>(&self, v: &'a str) {
         let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
         unsafe { wh::set_window_text(handle, v) }
+    }
+
+    /// Set the text in the current control, converting unix-style newlines in the input to "\r\n"
+    pub fn set_text_unix2dos<'a>(&self, v: &'a str) {
+        let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
+        unsafe { wh::set_window_text(handle,  &unix2dos(&v).to_string()) }
+    }
+
+    /// Append text to the current control
+    pub fn append<'a>(&self, v: &'a str) {
+        let text = self.text() + &unix2dos(&v).to_string();
+        self.set_text(&text);
+        self.scroll_lastline();
+    }
+
+    /// Append text to the current control followed by "\r\n"
+    pub fn appendln<'a>(&self, v: &'a str) {
+        let text = self.text() + &unix2dos(&v).to_string() + "\r\n";
+        self.set_text(&text);
+        self.scroll_lastline();
     }
 
     /// Winapi class name used during control creation

--- a/native-windows-gui/src/controls/text_box.rs
+++ b/native-windows-gui/src/controls/text_box.rs
@@ -4,7 +4,7 @@ use crate::win32::window_helper as wh;
 use crate::{Font, NwgError};
 use super::{ControlBase, ControlHandle};
 use std::ops::Range;
-use newline_converter::unix2dos;
+use newline_converter::{dos2unix, unix2dos};
 
 const NOT_BOUND: &'static str = "TextBox is not yet bound to a winapi object";
 const BAD_HANDLE: &'static str = "INTERNAL ERROR: TextBox handle is not HWND!";
@@ -188,16 +188,14 @@ impl TextBox {
         wh::send_message(handle, EM_SETSEL as u32, r.start as usize, r.end as isize);
     }
 
-    /// Return the length of the user input in the control. This is better than test.len() as it
-    /// does not allocate a string in memory
+    /// Return the length of the user input in the control. Performs a newline conversion first since
+    /// Windows treats "\r\n" as a single character
     pub fn len(&self) -> u32 {
-        use winapi::um::winuser::EM_LINELENGTH;
-        if self.handle.blank() { panic!("{}", NOT_BOUND); }
-        let handle = self.handle.hwnd().expect(BAD_HANDLE);
+        use std::convert::TryInto;
 
-        wh::send_message(handle, EM_LINELENGTH as u32, 0, 0) as u32
+        dos2unix(&self.text()).chars().count().try_into().unwrap_or_default()
     }
-
+    
     /// Return the number of lines in the multiline edit control.
     /// If the control has no text, the return value is 1.
     pub fn linecount(&self) -> i32 {
@@ -215,6 +213,13 @@ impl TextBox {
         if self.handle.blank() { panic!("{}", NOT_BOUND); }
         let handle = self.handle.hwnd().expect(BAD_HANDLE);
         wh::send_message(handle, EM_LINESCROLL as u32, 0, v as LPARAM);
+    }
+    
+    /// Get the linecount and then scroll the text to the last line
+    pub fn scroll_lastline(&self) {
+        let lines = self.linecount();
+        self.scroll(lines * -1);
+        self.scroll(lines - 2);
     }
 
     /// Return true if the TextInput value cannot be edited. Retrurn false otherwise.
@@ -338,14 +343,14 @@ impl TextBox {
     pub fn append<'a>(&self, v: &'a str) {
         let text = self.text() + &unix2dos(&v).to_string();
         self.set_text(&text);
-        self.scroll(self.linecount());
+        self.scroll_lastline();
     }
 
     /// Append text to the current control followed by "\r\n"
     pub fn appendln<'a>(&self, v: &'a str) {
         let text = self.text() + &unix2dos(&v).to_string() + "\r\n";
         self.set_text(&text);
-        self.scroll(self.linecount());
+        self.scroll_lastline();
     }
     
     /// Winapi class name used during control creation


### PR DESCRIPTION
Adds support for scrolling and appending to text boxes, uses unix2dos for making unix-style newlines seamless to append in text boxes. Adds echo_d example to demo scrolling and appending.