### PR TITLE
fix: fix plotters brush color

### DIFF
--- a/native-windows-gui/src/win32/plotters_d2d.rs
+++ b/native-windows-gui/src/win32/plotters_d2d.rs
@@ -133,10 +133,10 @@ impl Target {
                 };
             
                 let [r, g, b, a] = [
-                    color.r as f32 * 255.0,
-                    color.g as f32 * 255.0,
-                    color.b as f32 * 255.0,
-                    color.a as f32 * 255.0,
+                    color.r as f32 / 255.0,
+                    color.g as f32 / 255.0,
+                    color.b as f32 / 255.0,
+                    color.a as f32 / 255.0,
                 ];
     
                 unsafe {


### PR DESCRIPTION
The `Color` struct is of `u8`s, with the range of `[0, 255]`, we should do division here instead of multiplication when converting to `f32`s.