### PR TITLE
fix: fix plotters draw text overflow

### DIFF
--- a/native-windows-gui/src/win32/plotters_d2d.rs
+++ b/native-windows-gui/src/win32/plotters_d2d.rs
@@ -660,7 +660,7 @@ impl<'a> DrawingBackend for &'a PlottersBackend {
         unsafe {
             (&*target.render_target).DrawText(
                 raw_text.as_ptr(),
-                text.len() as _,
+                (raw_text.len() - 1) as _,
                 text_format,
                 &layout_rect,
                 brush as _,


### PR DESCRIPTION
When `text` contains CJK characters, the result of `text.len()` is not the number of characters, which is required by the `DrawText` method, which overflows the `raw_text` vector and resulting in drawing additional weird characters.

* https://docs.microsoft.com/en-us/windows/win32/api/d2d1/nf-d2d1-id2d1rendertarget-drawtext(constwchar_uint32_idwritetextformat_constd2d1_rect_f__id2d1brush_d2d1_draw_text_options_dwrite_measuring_mode)
* https://doc.rust-lang.org/std/primitive.str.html#method.len