### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/native-windows-gui/examples/sync-draw/src/shared_memory.rs
+++ b/native-windows-gui/examples/sync-draw/src/shared_memory.rs
@@ -128,8 +128,8 @@ impl SharedMemory {
     /// Fetch the next instance id in the shared memory.
     pub fn next_instance_id(&self) -> u32 {
         let header_ptr = SharedMemory::map_view(self.handle, 0, HEADER_SIZE) as *mut SharedHeader;
-        let next_id = unsafe {
-            let header = &mut *header_ptr;
+        let next_id = {
+            let header = unsafe { &mut *header_ptr };
             header.next_instance_id += 1;
             header.next_instance_id
         };
@@ -234,14 +234,14 @@ impl SharedMemory {
 
     /// Safe wrapper over MapViewOfFile
     fn map_view(handle: HANDLE, offset: DWORD, size: SIZE_T) -> *mut u8 {
-        unsafe {
-            let handle = MapViewOfFile(handle, FILE_MAP_ALL_ACCESS, 0, offset, size) as *mut u8;
+        
+            let handle = unsafe { MapViewOfFile(handle, FILE_MAP_ALL_ACCESS, 0, offset, size) as *mut u8 };
             if handle.is_null() {
                 panic!("Could not map memory region");
             }
 
             handle
-        }
+        
     }
 
     /// Safe wrapper over UnmapViewOfFile

--- a/native-windows-gui/src/win32/window_helper.rs
+++ b/native-windows-gui/src/win32/window_helper.rs
@@ -94,15 +94,15 @@ pub fn destroy_window(hwnd: HWND) {
 pub fn destroy_menu_item(parent: HMENU, item_id: u32) { 
     use winapi::um::winuser::{DeleteMenu, GetMenuItemCount, GetMenuItemID, MF_BYPOSITION};
 
-    unsafe {
-        let count = GetMenuItemCount(parent);
+    
+        let count = unsafe { GetMenuItemCount(parent) };
         let mut index = 0;
 
         while index < count {
-            let id = GetMenuItemID(parent, index);
+            let id = unsafe { GetMenuItemID(parent, index) };
             match id == item_id {
                 true => {
-                    DeleteMenu(parent, index as u32, MF_BYPOSITION);
+                    unsafe { DeleteMenu(parent, index as u32, MF_BYPOSITION) };
                     index = count;
                 },
                 false => {
@@ -110,7 +110,7 @@ pub fn destroy_menu_item(parent: HMENU, item_id: u32) {
                 }
             }
         }
-    }
+    
 }
 
 pub fn destroy_menu(menu: HMENU) { 


### PR DESCRIPTION
In this impl you use the unsafe keyword for many safe expressions. However, I found that only 2 operations are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. dereferencing raw pointers(*header_ptr/*self.data)
2. the MapViewOfFile()/BeginPaint()/DragQueryFileW()/set_len()/GetMenuItemID()/DeleteMenu() function(these are unsafe functions)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 