### PR TITLE
Fix event handler crash

### DIFF
--- a/native-windows-gui/src/win32/window.rs
+++ b/native-windows-gui/src/win32/window.rs
@@ -562,7 +562,10 @@ unsafe extern "system" fn process_events(hwnd: HWND, msg: UINT, w: WPARAM, l: LP
     use winapi::shared::minwindef::{HIWORD, LOWORD};
 
     let callback_ptr = data as *mut *const Callback;
-    let callback: &Callback = &**callback_ptr;
+    Rc::increment_strong_count(*callback_ptr);
+    let callback = Rc::from_raw(*callback_ptr);
+    let callback = &*callback;
+
     let base_handle = ControlHandle::Hwnd(hwnd);
 
     match msg {


### PR DESCRIPTION
Fixed a crash that occurs when an event handler is unbound from within its
own callback. The callback was being accessed without incrementing the
reference count, causing the callback to be dropped while still in use.