### PR TITLE
support multiple tray icons per parent

### DIFF
--- a/native-windows-gui/src/controls/control_base.rs
+++ b/native-windows-gui/src/controls/control_base.rs
@@ -1,7 +1,7 @@
 use winapi::shared::minwindef::DWORD;
 use winapi::shared::windef::{HWND};
 use super::ControlHandle;
-use crate::win32::window::{build_hwnd_control, build_timer, build_notice};
+use crate::win32::window::{build_hwnd_control, build_timer, build_notice, build_tray};
 use crate::{NwgError};
 
 #[cfg(feature = "menu")] use crate::win32::menu::build_hmenu_control;
@@ -277,7 +277,7 @@ impl OtherBuilder {
         let handle = self.parent.expect("Internal error. Control without window parent");
         let base = match self.ty {
             NOTICE => build_notice(handle),
-            TRAY => ControlHandle::SystemTray(handle),
+            TRAY => build_tray(handle),
             _ => unreachable!()
         };
 

--- a/native-windows-gui/src/controls/control_handle.rs
+++ b/native-windows-gui/src/controls/control_handle.rs
@@ -27,7 +27,7 @@ pub enum ControlHandle {
     Timer(HWND, u32),
 
     /// System tray control
-    SystemTray(HWND)
+    SystemTray(HWND, u32),
 }
 
 impl ControlHandle {
@@ -95,9 +95,9 @@ impl ControlHandle {
         }
     }
 
-    pub fn tray(&self) -> Option<HWND> {
+    pub fn tray(&self) -> Option<(HWND, u32)> {
         match self {
-            &ControlHandle::SystemTray(h) => Some(h),
+            &ControlHandle::SystemTray(h, i) => Some((h, i)),
             _ => None,
         }
     }
@@ -152,8 +152,8 @@ impl PartialEq for ControlHandle {
                 _ => false
             },
             // System tray
-            &ControlHandle::SystemTray(hwnd1) => match other {
-                &ControlHandle::SystemTray(hwnd2) => hwnd1 == hwnd2,
+            &ControlHandle::SystemTray(hwnd1, id1) => match other {
+                &ControlHandle::SystemTray(hwnd2, id2) => hwnd1 == hwnd2 && id1 == id2,
                 _ => false
             }
         }

--- a/native-windows-gui/src/win32/window.rs
+++ b/native-windows-gui/src/win32/window.rs
@@ -22,6 +22,7 @@ use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
 static TIMER_ID: AtomicU32 = AtomicU32::new(1); 
 static NOTICE_ID: AtomicU32 = AtomicU32::new(1); 
+static TRAY_ID: AtomicU32 = AtomicU32::new(1);
 static EVENT_HANDLER_ID: AtomicUsize = AtomicUsize::new(1);
 
 const NO_DATA: EventData = EventData::NoData;
@@ -68,6 +69,12 @@ pub unsafe fn build_timer(parent: HWND, interval: u32, stopped: bool) -> Control
     }
     
     ControlHandle::Timer(parent, id)
+}
+
+
+pub fn build_tray(parent: HWND) -> ControlHandle {
+    let id = TRAY_ID.fetch_add(1, Ordering::SeqCst);
+    ControlHandle::SystemTray(parent, id)
 }
 
 /**
@@ -665,7 +672,8 @@ unsafe extern "system" fn process_events(hwnd: HWND, msg: UINT, w: WPARAM, l: LP
         },
         NWG_TRAY => {
             let msg = LOWORD(l as u32) as u32;
-            let handle = ControlHandle::SystemTray(hwnd);
+            let icon_id = HIWORD(l as u32) as u32;
+            let handle = ControlHandle::SystemTray(hwnd, icon_id);
 
             match msg {
                 NIN_BALLOONSHOW => callback(Event::OnTrayNotificationShow, NO_DATA, handle),


### PR DESCRIPTION
Just like a parent (HWND) can have multiple timers, it can have multiple notification area icons (TrayNotifications) differentiated by an ID. Use similar functionality as with timers to extend support to multiple icons per parent.

The `Shell_NotifyIconW(NIM_SETVERSION, &mut data);` call is necessary to ensure that the icon ID is passed in the expected format to `process_events(...)`, as the version field is ignored otherwise (well, interpreted as the timeout value). This has been previously pointed out by @iquanxin in issue #246.