### PR TITLE
Allow to set a default filter in file dialogs

### DIFF
--- a/native-windows-gui/examples/image_decoder_d.rs
+++ b/native-windows-gui/examples/image_decoder_d.rs
@@ -29,7 +29,7 @@ pub struct ImageDecoderApp {
     #[nwg_resource]
     decoder: nwg::ImageDecoder,
 
-    #[nwg_resource(title: "Open File", action: nwg::FileDialogAction::Open, filters: "Png(*.png)|Jpeg(*.jpg;*.jpeg)|DDS(*.dds)|TIFF(*.tiff)|BMP(*.bmp)|Any (*.*)")]
+    #[nwg_resource(title: "Open File", action: nwg::FileDialogAction::Open, filters: "Png(*.png)|Jpeg(*.jpg;*.jpeg)|DDS(*.dds)|TIFF(*.tiff)|BMP(*.bmp)|>Any (*.*)")]
     dialog: nwg::FileDialog,
 
     #[nwg_control(text: "Open", focus: true)]

--- a/native-windows-gui/src/resources/file_dialog.rs
+++ b/native-windows-gui/src/resources/file_dialog.rs
@@ -29,7 +29,8 @@ pub enum FileDialogAction {
     * multiselect: Whether the user can select more than one file. Only supported with the Open action
     * default_folder: Default folder to show in the dialog.
     * filters: If defined, filter the files that the user can select (In a Open dialog) or which extension to add to the saved file (in a Save dialog)
-    The `filters` value must be a '|' separated string having this format: "Test(*.txt;*.rs)|Any(*.*)"  
+    The `filters` value must be a '|' separated string having this format: "Test(*.txt;*.rs)|Any(*.*)".  
+    If one of the filters has its name prefixed with '>' (like ">Test"), it will become the default filter. 
 
     ```rust
         use native_windows_gui as nwg;
@@ -168,7 +169,8 @@ impl FileDialog {
         This can only be set ONCE (the initialization counts) and won't work if the dialog is `OpenDirectory`.  
        
         The `filters` value must be a '|' separated string having this format: "Test(*.txt;*.rs)|Any(*.*)"  
-        Where the fist part is the "human name" and the second part is a filter for the system.
+        Where the first part is the "human name" and the second part is a filter for the system. If the
+        human name starts with a '>', the '>' is removed and the filter associated with it becomes the default.  
     */
     pub fn set_filters<'a>(&self, filters: &'a str) -> Result<(), NwgError> {
         unsafe{ 

--- a/native-windows-gui/src/win32/resources_helper.rs
+++ b/native-windows-gui/src/win32/resources_helper.rs
@@ -391,7 +391,7 @@ pub unsafe fn create_file_dialog<'a, 'b>(
     match &filters {
         &Some(ref f) => match file_dialog_set_filters(file_dialog, f) {
             Ok(_) => (),
-            Err(e) => { println!("set filters"); file_dialog.Release(); return Err(e); }
+            Err(e) => { file_dialog.Release(); return Err(e); }
         },
         &None => ()
     }


### PR DESCRIPTION
It was weird that I couldn't make one of the filters the default option.

Prior to this change, the first filter is always the default. Now, the filter prefixed with `>` is the default. 

I chose `>` because you can't name a file with it.

Here's a file dialog with the filter string `PNG(*.png)|JPEG(*.jpg;*.jpeg)|WebP(*.webp)|>Supported image files(*.png;*.jpg;*.jpeg;*.webp)`:

![image](https://user-images.githubusercontent.com/7030150/209474391-7c1e06f1-f0b9-4a8c-9008-cddfabd9edcb.png)
