### PR TITLE
fix: prevent DC leaking on getting DPI

### DIFF
--- a/native-windows-gui/src/win32/high_dpi.rs
+++ b/native-windows-gui/src/win32/high_dpi.rs
@@ -58,5 +58,6 @@ pub unsafe fn dpi() -> i32 {
     use winapi::um::wingdi::LOGPIXELSX;
     let screen = GetDC(std::ptr::null_mut());
     let dpi = GetDeviceCaps(screen, LOGPIXELSX);
+    let _ = ReleaseDC(std::ptr::null_mut(),screen);
     dpi
 }


### PR DESCRIPTION
This seems to work, but haven't tested it much

Closes https://github.com/gabdube/native-windows-gui/issues/301