### PR TITLE
Add dark mode support

### DIFF
--- a/native-windows-gui/Cargo.toml
+++ b/native-windows-gui/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["gui", "ui", "windows"]
 winapi = { version = "0.3", features = [
   "winuser", "wingdi", "winbase", "libloaderapi", "processthreadsapi",
   "errhandlingapi", "winerror", "commctrl", "sysinfoapi", "shobjidl", "combaseapi",
-  "commdlg", "d2d1", "objbase", "dwrite", "winnls", "shellapi", "wincodec", "stringapiset"] }
+  "commdlg", "d2d1", "objbase", "dwrite", "winnls", "shellapi", "wincodec", "stringapiset", "dwmapi"] }
 
 lazy_static = "1.4.0"
 bitflags = "1.1.0"

--- a/native-windows-gui/Cargo.toml
+++ b/native-windows-gui/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["gui", "ui", "windows"]
 winapi = { version = "0.3", features = [
   "winuser", "wingdi", "winbase", "libloaderapi", "processthreadsapi",
   "errhandlingapi", "winerror", "commctrl", "sysinfoapi", "shobjidl", "combaseapi",
-  "commdlg", "d2d1", "objbase", "dwrite", "winnls", "shellapi", "wincodec", "stringapiset", "dwmapi"] }
+  "commdlg", "d2d1", "objbase", "dwrite", "winnls", "shellapi", "wincodec", "stringapiset", "dwmapi", "impl-default"] }
 
 lazy_static = "1.4.0"
 bitflags = "1.1.0"

--- a/native-windows-gui/src/win32/window.rs
+++ b/native-windows-gui/src/win32/window.rs
@@ -353,6 +353,15 @@ pub fn unbind_raw_event_handler(handler: &RawEventHandler) -> Result<(), NwgErro
     }
 }
 
+/// Enables dark mode support for a top-level window.
+/// This function only affects the titlebar's color.
+///
+/// # Arguments
+///
+/// * `hwnd`: The handle to a top-level window which should support dark mode.
+///
+/// returns: Result<(), String>
+///
 unsafe fn enable_dark_mode_for_window(hwnd: HWND) -> Result<(), String> {
     let value: BOOL = TRUE;
     let result: HRESULT = winapi::um::dwmapi::DwmSetWindowAttribute(
@@ -734,7 +743,9 @@ unsafe extern "system" fn process_events(hwnd: HWND, msg: UINT, w: WPARAM, l: LP
         NWG_TIMER_STOP => callback(Event::OnTimerStop, NO_DATA, ControlHandle::Timer(hwnd, w as u32)),
         NWG_TIMER_TICK => callback(Event::OnTimerTick, NO_DATA, ControlHandle::Timer(hwnd, w as u32)),
         NWG_INIT => {
-            enable_dark_mode_for_window(hwnd).expect("Failed to enable dark mode for window");
+            if enable_dark_mode_for_window(hwnd).is_err() {
+                println!("enable_dark_mode_for_window failed, is the Windows version too old?");
+            }
             callback(Event::OnInit, NO_DATA, base_handle)
         },
         WM_CLOSE => {


### PR DESCRIPTION
# Summary

Adds dark mode support, which only affects the titlebar.

The dark mode setting is applied and refreshes based on OS settings.

# Additional Context

It might be a good idea to provide an override API with which library consumers can specify their desired dark mode state.
