### PR TITLE
Add blocking dispatch_thread_events function

### DIFF
--- a/native-windows-gui/src/lib.rs
+++ b/native-windows-gui/src/lib.rs
@@ -24,7 +24,9 @@ pub use common_types::*;
 
 pub(crate) mod win32;
 pub use win32::{
- dispatch_thread_events, dispatch_thread_events_with_callback, stop_thread_dispatch, enable_visual_styles, init_common_controls, 
+ dispatch_thread_events, dispatch_thread_events_with_callback,
+ dispatch_thread_events_blocking_with_callback,
+ stop_thread_dispatch, enable_visual_styles, init_common_controls,
  window::{
      EventHandler, RawEventHandler,
      full_bind_event_handler, bind_event_handler, unbind_event_handler,

--- a/native-windows-gui/src/win32/mod.rs
+++ b/native-windows-gui/src/win32/mod.rs
@@ -82,6 +82,27 @@ pub fn dispatch_thread_events_with_callback<F>(mut cb: F)
 }
 
 /**
+    Dispatch system events in the current thread AND execute a callback after each message received.
+*/
+pub fn dispatch_thread_events_blocking_with_callback<F>(mut cb: F)
+    where F: FnMut() -> () + 'static
+{
+    use winapi::um::winuser::GetMessageW;
+    use winapi::um::winuser::MSG;
+
+    unsafe {
+        let mut msg: MSG = mem::zeroed();
+        while GetMessageW(&mut msg, ptr::null_mut(), 0, 0) != 0 {
+            if IsDialogMessageW(GetAncestor(msg.hwnd, GA_ROOT), &mut msg) == 0 {
+                TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+            cb();
+        }
+    }
+}
+
+/**
     Break the events loop running on the current thread
 */
 pub fn stop_thread_dispatch() {


### PR DESCRIPTION
I had problems with the `dispatch_thread_events_with_callback` function either letting me have a responsive UI with high CPU usage or having to add a sleep of some sort into my callback (which made the window not work properly with focus).
This PR adds a `dispatch_thread_events_blocking_with_callback` function that mirrors the `dispatch_thread_events` function in that it blocks for new messages, but it adds a callback after each message is handled. This results in low CPU usage.

My use case:
I have a program that runs a local `Future`s executor in the main thread, but I don't want to block the UI. I was previously using the dispatch_thread_events_with_callback function, but it resulted in high CPU usage until I added a WaitMessage to the end of my callback. However, when I added that, it would then not work properly when trying to bring the window into focus.