### PR TITLE
Replace transmuted references with explicit pointer type casts

### DIFF
--- a/native-windows-gui/src/controls/extern_canvas.rs
+++ b/native-windows-gui/src/controls/extern_canvas.rs
@@ -130,14 +130,13 @@ impl ExternCanvas {
     /// - icon: The new icon. If None, the icon is removed
     pub fn set_icon(&self, icon: Option<&Icon>) {
         use winapi::um::winuser::WM_SETICON;
-        use std::{mem, ptr};
+        use winapi::shared::minwindef::LPARAM;
+        use std::ptr;
 
         let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
 
         let image_handle = icon.map(|i| i.handle).unwrap_or(ptr::null_mut());
-        unsafe {
-            wh::send_message(handle, WM_SETICON, 0, mem::transmute(image_handle));
-        }
+        wh::send_message(handle, WM_SETICON, 0, image_handle as LPARAM);
     }
 
     /// Return true if the control currently has the keyboard focus

--- a/native-windows-gui/src/controls/list_box.rs
+++ b/native-windows-gui/src/controls/list_box.rs
@@ -106,9 +106,7 @@ impl<D: Display+Default> ListBox<D> {
         let display = format!("{}", item);
         let display_os = to_utf16(&display);
 
-        unsafe {
-            wh::send_message(handle, LB_ADDSTRING, 0, mem::transmute(display_os.as_ptr()));
-        }
+        wh::send_message(handle, LB_ADDSTRING, 0, display_os.as_ptr() as LPARAM);
 
         self.collection.borrow_mut().push(item);
     }
@@ -131,9 +129,7 @@ impl<D: Display+Default> ListBox<D> {
             col.insert(index, item);
         }
 
-        unsafe {
-            wh::send_message(handle, LB_INSERTSTRING, index, mem::transmute(display_os.as_ptr()));
-        }
+        wh::send_message(handle, LB_INSERTSTRING, index, display_os.as_ptr() as LPARAM);
     }
 
 
@@ -215,10 +211,8 @@ impl<D: Display+Default> ListBox<D> {
             let index = index as usize;
             let length = (wh::send_message(handle, LB_GETTEXTLEN, index, 0) as usize) + 1;  // +1 for the terminating null character
             let mut buffer: Vec<WCHAR> = Vec::with_capacity(length);
-            unsafe { 
-                buffer.set_len(length); 
-                wh::send_message(handle, LB_GETTEXT, index, mem::transmute(buffer.as_ptr()));
-            }
+            unsafe { buffer.set_len(length); }
+            wh::send_message(handle, LB_GETTEXT, index, buffer.as_ptr() as LPARAM);
 
             Some(from_utf16(&buffer))
         }
@@ -292,13 +286,11 @@ impl<D: Display+Default> ListBox<D> {
         let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
         let os_string = to_utf16(value);
 
-        unsafe {
-            let index = wh::send_message(handle, LB_SELECTSTRING, 0, mem::transmute(os_string.as_ptr()));
-            if index == LB_ERR {
-                None
-            } else {
-                Some(index as usize)
-            }
+        let index = wh::send_message(handle, LB_SELECTSTRING, 0, os_string.as_ptr() as LPARAM);
+        if index == LB_ERR {
+            None
+        } else {
+            Some(index as usize)
         }
     }
 
@@ -327,9 +319,7 @@ impl<D: Display+Default> ListBox<D> {
             let display = format!("{}", item);
             let display_os = to_utf16(&display);
             
-            unsafe {
-                wh::send_message(handle, LB_ADDSTRING, 0, mem::transmute(display_os.as_ptr()));
-            }
+            wh::send_message(handle, LB_ADDSTRING, 0, display_os.as_ptr() as LPARAM);
         }
     }
 
@@ -345,9 +335,7 @@ impl<D: Display+Default> ListBox<D> {
             let display = format!("{}", item);
             let display_os = to_utf16(&display);
             
-            unsafe {
-                wh::send_message(handle, LB_ADDSTRING, 0, mem::transmute(display_os.as_ptr()));
-            }
+            wh::send_message(handle, LB_ADDSTRING, 0, display_os.as_ptr() as LPARAM);
         }
 
         let mut col_ref = self.collection.borrow_mut();

--- a/native-windows-gui/src/controls/window.rs
+++ b/native-windows-gui/src/controls/window.rs
@@ -158,14 +158,13 @@ impl Window {
     /// - icon: The new icon. If None, the icon is removed
     pub fn set_icon(&self, icon: Option<&Icon>) {
         use winapi::um::winuser::WM_SETICON;
-        use std::{mem, ptr};
+        use winapi::shared::minwindef::LPARAM;
+        use std::ptr;
 
         let handle = check_hwnd(&self.handle, NOT_BOUND, BAD_HANDLE);
 
         let image_handle = icon.map(|i| i.handle).unwrap_or(ptr::null_mut());
-        unsafe {
-            wh::send_message(handle, WM_SETICON, 0, mem::transmute(image_handle));
-        }
+        wh::send_message(handle, WM_SETICON, 0, image_handle as LPARAM);
     }
 
     /// Return true if the control currently has the keyboard focus

--- a/native-windows-gui/src/resources/file_dialog.rs
+++ b/native-windows-gui/src/resources/file_dialog.rs
@@ -1,4 +1,4 @@
-use winapi::um::shobjidl::IFileDialog;
+use winapi::um::shobjidl::{IFileDialog, IFileOpenDialog};
 use crate::win32::resources_helper as rh;
 
 use crate::win32::base_helper::to_utf16;
@@ -115,7 +115,7 @@ impl FileDialog {
         }
 
         unsafe {
-            rh::filedialog_get_items(mem::transmute(&mut *self.handle))
+            rh::filedialog_get_items(&mut *(self.handle as *mut IFileOpenDialog))
         }
     }
 

--- a/native-windows-gui/src/win32/menu.rs
+++ b/native-windows-gui/src/win32/menu.rs
@@ -1,6 +1,7 @@
 /*!
 Native Windows GUI menu base.
 */
+use winapi::shared::basetsd::UINT_PTR;
 use winapi::shared::windef::{HMENU, HWND};
 use winapi::shared::minwindef::UINT;
 use super::base_helper::{CUSTOM_ID_BEGIN, to_utf16};
@@ -70,7 +71,7 @@ pub unsafe fn build_hmenu_control(text: Option<String>, item: bool, separator: b
                 return Err(NwgError::menu_create("Menu without parent"));
             }
             use_menu_command(menu);
-            AppendMenuW(menubar, flags, mem::transmute(menu), text.as_ptr());
+            AppendMenuW(menubar, flags, menu as UINT_PTR, text.as_ptr());
         }
 
         // Draw the menu bar to make sure the changes are visible
@@ -89,7 +90,7 @@ pub unsafe fn build_hmenu_control(text: Option<String>, item: bool, separator: b
                 return Err(NwgError::menu_create("Menu without parent"));
             }
             use_menu_command(menu);
-            AppendMenuW(parent, flags, mem::transmute(menu), text.as_ptr());
+            AppendMenuW(parent, flags, menu as UINT_PTR, text.as_ptr());
         }
     }
 

--- a/native-windows-gui/src/win32/resources_helper.rs
+++ b/native-windows-gui/src/win32/resources_helper.rs
@@ -349,6 +349,7 @@ pub unsafe fn create_file_dialog<'a, 'b>(
     use winapi::um::shobjidl::{FOS_PICKFOLDERS, FOS_ALLOWMULTISELECT, FOS_FORCEFILESYSTEM};
     use winapi::um::combaseapi::CoCreateInstance;
     use winapi::shared::{wtypesbase::CLSCTX_INPROC_SERVER, winerror::S_OK};
+    use winapi::shared::minwindef::LPVOID;
 
     let (clsid, uuid) = match action {
         FileDialogAction::Save => (CLSID_FileSaveDialog, IFileDialog::uuidof()),
@@ -356,7 +357,7 @@ pub unsafe fn create_file_dialog<'a, 'b>(
     };
 
     let mut handle: *mut IFileDialog = ptr::null_mut();
-    let r = CoCreateInstance(&clsid, ptr::null_mut(), CLSCTX_INPROC_SERVER, &uuid, mem::transmute(&mut handle) );
+    let r = CoCreateInstance(&clsid, ptr::null_mut(), CLSCTX_INPROC_SERVER, &uuid, &mut handle as *mut _ as *mut LPVOID);
     if r != S_OK {
         return Err(NwgError::file_dialog("Filedialog creation failed"));
     }
@@ -418,7 +419,7 @@ pub unsafe fn file_dialog_set_default_folder<'a>(dialog: &mut IFileDialog, folde
     let mut shellitem: *mut IShellItem = ptr::null_mut();
     let path = to_utf16(&folder_name);
 
-    if SHCreateItemFromParsingName(path.as_ptr(), ptr::null_mut(), &IShellItem::uuidof(), mem::transmute(&mut shellitem) ) != S_OK {
+    if SHCreateItemFromParsingName(path.as_ptr(), ptr::null_mut(), &IShellItem::uuidof(), &mut shellitem as *mut _ as *mut *mut c_void) != S_OK {
         return Err(NwgError::file_dialog("Failed to set default folder"));
     }
 
@@ -504,7 +505,7 @@ pub unsafe fn filedialog_get_items(dialog: &mut IFileOpenDialog) -> Result<Vec<O
     let mut _item: *mut IShellItem = ptr::null_mut();
     let mut _items: *mut IShellItemArray = ptr::null_mut();
 
-    if dialog.GetResults( mem::transmute(&mut _items) ) != S_OK {
+    if dialog.GetResults(&mut _items as *mut _) != S_OK {
         return Err(NwgError::file_dialog("Failed to get dialog items"));
     }
 
@@ -530,6 +531,7 @@ pub unsafe fn filedialog_get_items(dialog: &mut IFileOpenDialog) -> Result<Vec<O
 unsafe fn get_ishellitem_path(item: &mut IShellItem) -> Result<OsString, NwgError> {
     use winapi::um::shobjidl_core::SIGDN_FILESYSPATH;
     use winapi::shared::{ntdef::PWSTR, winerror::S_OK};
+    use winapi::shared::minwindef::LPVOID;
     use winapi::um::combaseapi::CoTaskMemFree;
     use super::base_helper::os_string_from_wide_ptr;
 
@@ -540,7 +542,7 @@ unsafe fn get_ishellitem_path(item: &mut IShellItem) -> Result<OsString, NwgErro
 
     let text = os_string_from_wide_ptr(item_path, None);
 
-    CoTaskMemFree(mem::transmute(item_path));
+    CoTaskMemFree(item_path as LPVOID);
 
     Ok(text)
 }

--- a/native-windows-gui/src/win32/window.rs
+++ b/native-windows-gui/src/win32/window.rs
@@ -597,17 +597,17 @@ unsafe extern "system" fn process_events(hwnd: HWND, msg: UINT, w: WPARAM, l: LP
         },
         WM_NOTIFY => {
             let code = {
-                let notif_ptr: *mut NMHDR = mem::transmute(l);
+                let notif_ptr = l as *mut NMHDR;
                 (&*notif_ptr).code
             };
         
             match code {
-                TTN_GETDISPINFOW => handle_tooltip_callback(mem::transmute::<_, *mut NMTTDISPINFOW>(l), callback),
-                _ => handle_default_notify_callback(mem::transmute::<_, *const NMHDR>(l), callback)
+                TTN_GETDISPINFOW => handle_tooltip_callback(l as *mut NMTTDISPINFOW, callback),
+                _ => handle_default_notify_callback(l as *const NMHDR, callback)
             }
         },
         WM_MENUCOMMAND => {
-            let parent_handle: HMENU = mem::transmute(l);
+            let parent_handle = l as HMENU;
             let item_id = GetMenuItemID(parent_handle, w as i32);
             let handle = ControlHandle::MenuItem(parent_handle, item_id);
             callback(Event::OnMenuItemSelected, NO_DATA, handle);
@@ -1074,7 +1074,12 @@ unsafe fn GetWindowSubclass(hwnd: HWND, proc: SUBCLASSPROC, uid: UINT_PTR, data:
         SUBCLASS_COLLECTION = Some(Mutex::new(HashMap::new()));
     }
 
-    let id = (hwnd as usize, mem::transmute(proc), uid);
+    let proc_id = match proc {
+        Some(p) => p as usize,
+        None => 0
+    };
+
+    let id = (hwnd as usize, proc_id, uid);
     match SUBCLASS_COLLECTION.as_ref() {
         Some(collection_mutex) => {
             let collection = collection_mutex.lock().unwrap();
@@ -1096,7 +1101,12 @@ unsafe fn SetWindowSubclass(hwnd: HWND, proc: SUBCLASSPROC, uid: UINT_PTR, data:
         SUBCLASS_COLLECTION = Some(Mutex::new(HashMap::new()));
     }
 
-    let id = (hwnd as usize, mem::transmute(proc), uid);
+    let proc_id = match proc {
+        Some(p) => p as usize,
+        None => 0
+    };
+
+    let id = (hwnd as usize, proc_id, uid);
     match SUBCLASS_COLLECTION.as_ref() {
         Some(collection_mutex) => {
             let mut collection = collection_mutex.lock().unwrap();
@@ -1119,7 +1129,12 @@ unsafe fn RemoveWindowSubclass(hwnd: HWND, proc: SUBCLASSPROC, uid: UINT_PTR) ->
         SUBCLASS_COLLECTION = Some(Mutex::new(HashMap::new()));
     }
 
-    let id = (hwnd as usize, mem::transmute(proc), uid);
+    let proc_id = match proc {
+        Some(p) => p as usize,
+        None => 0
+    };
+
+    let id = (hwnd as usize, proc_id, uid);
     match SUBCLASS_COLLECTION.as_ref() {
         Some(collection_mutex) => {
             let mut collection = collection_mutex.lock().unwrap();

--- a/native-windows-gui/src/win32/window_helper.rs
+++ b/native-windows-gui/src/win32/window_helper.rs
@@ -169,10 +169,7 @@ pub fn get_window_parent(hwnd: HWND) -> HWND {
 
 pub fn get_window_font(handle: HWND) -> HFONT {
     use winapi::um::winuser::{ WM_GETFONT };
-    unsafe { 
-        let h = send_message(handle, WM_GETFONT, 0, 0);
-        mem::transmute(h)
-    }
+    send_message(handle, WM_GETFONT, 0, 0) as HFONT
 }
 
 pub fn maximize_window(handle: HWND) {
@@ -203,7 +200,7 @@ pub unsafe fn set_window_font(handle: HWND, font_handle: Option<HFONT>, redraw: 
 
     let font_handle = font_handle.unwrap_or(ptr::null_mut());
 
-    SendMessageW(handle, WM_SETFONT, mem::transmute(font_handle), redraw as LPARAM);
+    SendMessageW(handle, WM_SETFONT, font_handle as WPARAM, redraw as LPARAM);
 }
 
 


### PR DESCRIPTION
# Description

Rust docs about `std::mem::transmute` read:

> Transmuting integers to pointers is a largely unspecified operation. It is likely not equivalent to an as cast. **Doing non-zero-sized memory accesses with a pointer constructed this way is currently considered undefined behavior**.

Source: https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers

Although this library mostly transmutes to reference `Dst` types and not pointers, from my understanding the same rules apply for references as well. Additionally, code in the library sometimes transmutes to mutable references, which is even worse because strict aliasing rules may not be respected in that case.

# Motivation

An [issue](https://github.com/nickbeth/wsl-usb-manager/issues/8) was opened for my app, a Win32 GUI for WSL USB device management, reporting that release builds would crash at startup, with a `STATUS_ILLEGAL_INSTRUCTION` return code.  
Upon further inspection, the issue boiled down to these transmutes [[1]](https://github.com/gabdube/native-windows-gui/blob/a6c96e8de5d01fe7bb566d737622dfead3cd1aed/native-windows-gui/src/controls/tabs.rs#L760) [[2]](https://github.com/gabdube/native-windows-gui/blob/a6c96e8de5d01fe7bb566d737622dfead3cd1aed/native-windows-gui/src/controls/tabs.rs#L771) in the tabs code. In that specific instance, UB was introduced, and for any `opt-level > 0` the generated code would `callq` into a panic handler without a conditional jump before it, return from the handler and execute an `ud2` instruction.

This was tested on Windows 11, Rust 1.82.0.

# Change proposal

`std::mem::transmute` instances that would introduce UB are removed in favor of explicit type casts, and references are changed to pointers. There's many instances of `std::mem::transmute` being used incorrectly, this PR fixes all offending instances.